### PR TITLE
feat(chart): harden upgrade ergonomics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,9 +64,13 @@ jobs:
       image: debian:trixie-slim
       options: --user root
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
       - name: Install Varnish and build tools
         run: |
           export DEBIAN_FRONTEND=noninteractive
+          VARNISH_VERSION=$(awk -F'"' '/^  varnishVersion:/{print $2; exit}' charts/varnish-gateway/values.yaml)
           apt-get update
           apt-get install -y curl gpg dirmngr
           mkdir -p /etc/apt/keyrings
@@ -80,10 +84,7 @@ jobs:
           apt-get update
           apt-get install -y --no-install-recommends \
             build-essential pkg-config clang libclang-dev git \
-            varnish varnish-dev
-
-      - name: Checkout
-        uses: actions/checkout@v6
+            "varnish=${VARNISH_VERSION}*" "varnish-dev=${VARNISH_VERSION}*"
 
       - name: Set up Rust
         run: |
@@ -101,3 +102,22 @@ jobs:
 
       - name: Run VTC integration tests
         run: cd ghost && cargo test --release run_vtc_tests
+
+  helm-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: '3.14.0'
+
+      # Lints the chart, validates values.schema.json, and renders the chart
+      # against every fixture in charts/varnish-gateway/test/fixtures. Catches
+      # nil-pointer regressions from new top-level value keys without a
+      # `(.Values.X).foo` style guard — the failure mode that broke
+      # --reuse-values across the 0.18.5 → 0.20.0 upgrade.
+      - name: Run helm-test
+        run: make helm-test

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -203,6 +203,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Read pinned Varnish version
+        id: varnish
+        run: echo "version=$(awk -F'\"' '/^  varnishVersion:/{print $2; exit}' charts/varnish-gateway/values.yaml)" >> $GITHUB_OUTPUT
+
       - name: Build and push by digest
         id: build
         uses: docker/build-push-action@v6
@@ -210,6 +214,8 @@ jobs:
           context: .
           file: docker/chaperone.Dockerfile
           platforms: ${{ matrix.platform }}
+          build-args: |
+            VARNISH_VERSION=${{ steps.varnish.outputs.version }}
           outputs: type=image,name=${{ env.IMAGE_PREFIX }}/gateway-chaperone,push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha,scope=chaperone-${{ matrix.platform }}
           cache-to: type=gha,scope=chaperone-${{ matrix.platform }},mode=max

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 VERSION := $(shell cat .version)
 CHART_VERSION := $(shell cat .version | sed 's/^v//')
+# Single source of truth: charts/varnish-gateway/values.yaml.
+VARNISH_VERSION := $(shell awk -F'"' '/^  varnishVersion:/{print $$2; exit}' charts/varnish-gateway/values.yaml)
 REGISTRY ?= ghcr.io/varnish
 OPERATOR_IMAGE := $(REGISTRY)/gateway-operator
 CHAPERONE_IMAGE := $(REGISTRY)/gateway-chaperone
@@ -7,7 +9,7 @@ CHAPERONE_IMAGE := $(REGISTRY)/gateway-chaperone
 
 .PHONY: help test build build-linux docker clean vendor act
 .PHONY: build-go test-go test-envtest envtest install-envtest build-ghost test-ghost
-.PHONY: helm-lint helm-template
+.PHONY: helm-lint helm-template helm-test
 .PHONY: test-conformance test-conformance-report test-conformance-single
 .PHONY: kind-create kind-delete kind-load kind-deploy test-conformance-kind
 .PHONY: manifests generate verify-manifests
@@ -172,7 +174,7 @@ docker-operator:
 	docker tag $(OPERATOR_IMAGE):$(VERSION) $(OPERATOR_IMAGE):latest
 
 docker-chaperone:
-	docker build -t $(CHAPERONE_IMAGE):$(VERSION) -f docker/chaperone.Dockerfile .
+	docker build --build-arg VARNISH_VERSION=$(VARNISH_VERSION) -t $(CHAPERONE_IMAGE):$(VERSION) -f docker/chaperone.Dockerfile .
 	docker tag $(CHAPERONE_IMAGE):$(VERSION) $(CHAPERONE_IMAGE):latest
 
 # ============================================================================
@@ -380,6 +382,17 @@ helm-lint:
 
 helm-template:
 	helm template $(RELEASE_NAME) $(CHART_PATH) --debug
+
+# Render the chart against every fixture in test/fixtures/values-*.yaml.
+# Catches nil-pointer regressions from new top-level value keys (mirrors the
+# `--reuse-values` failure mode that broke the 0.18.5 → 0.20.0 upgrade).
+helm-test: helm-lint
+	@helm template $(RELEASE_NAME) $(CHART_PATH) >/dev/null
+	@for f in $(CHART_PATH)/test/fixtures/values-*.yaml; do \
+		echo "==> rendering against $$f"; \
+		helm template $(RELEASE_NAME) $(CHART_PATH) -f $$f >/dev/null || exit 1; \
+	done
+	@echo "All chart fixture renders OK."
 
 # ============================================================================
 # Code generation (controller-gen)

--- a/charts/varnish-gateway/templates/NOTES.txt
+++ b/charts/varnish-gateway/templates/NOTES.txt
@@ -1,3 +1,35 @@
+{{- if .Release.IsUpgrade }}
+{{ .Chart.Name }} upgraded to chart {{ .Chart.Version }} (app {{ .Chart.AppVersion }}).
+
+Release: {{ .Release.Name }}
+Namespace: {{ include "varnish-gateway.namespace" . }}
+
+Chaperone image: {{ .Values.chaperone.image.repository }}:{{ .Values.chaperone.image.tag | default .Chart.AppVersion }}
+{{- with (.Values.chaperone).varnishVersion }}
+Bundled Varnish: {{ . }}
+  → If you load custom VMODs, they must be built against this Varnish version.
+    See: https://github.com/varnish/gateway/blob/main/docs/operations/custom-vmods.md
+{{- end }}
+
+Recommended upgrade command
+---------------------------
+Use --reset-then-reuse-values --force-conflicts (NOT --reuse-values) so new
+top-level value keys introduced by this chart version inherit defaults
+instead of crashing the template render with a nil-pointer error:
+
+    helm upgrade {{ .Release.Name }} oci://ghcr.io/varnish/charts/varnish-gateway \
+        --version {{ .Chart.Version }} \
+        --namespace {{ include "varnish-gateway.namespace" . }} \
+        --reset-then-reuse-values \
+        --force-conflicts
+
+Per-release upgrade notes and breaking changes:
+  https://github.com/varnish/gateway/blob/main/docs/operations/upgrades.md
+
+Verify the rollout:
+  kubectl -n {{ include "varnish-gateway.namespace" . }} rollout status deployment/varnish-gateway-operator
+  kubectl get gateway -A
+{{- else }}
 Thank you for installing {{ .Chart.Name }}!
 
 Your release is named {{ .Release.Name }}.
@@ -8,6 +40,10 @@ Gateway API Resources Created:
   - GatewayClass: {{ .Values.gatewayClass.name }}
 {{- if .Values.gatewayClass.createDefaultParams }}
   - GatewayClassParameters: {{ .Values.gatewayClass.defaultParams.name }}
+{{- end }}
+{{- with (.Values.chaperone).varnishVersion }}
+
+Chaperone bundles Varnish {{ . }}. Custom VMODs must be built against this version.
 {{- end }}
 
 To get started:
@@ -66,3 +102,4 @@ To get started:
 For more information, visit:
   - Documentation: https://github.com/varnish/gateway
   - Issues: https://github.com/varnish/gateway/issues
+{{- end }}

--- a/charts/varnish-gateway/templates/chaperone-podmonitor.yaml
+++ b/charts/varnish-gateway/templates/chaperone-podmonitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceMonitor.enabled }}
+{{- if (.Values.serviceMonitor).enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:

--- a/charts/varnish-gateway/templates/dashboards-configmap.yaml
+++ b/charts/varnish-gateway/templates/dashboards-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.dashboards.enabled }}
+{{- if (.Values.dashboards).enabled }}
 {{- range $path, $_ := .Files.Glob "dashboards/*.json" }}
 {{- $name := regexReplaceAll "\\.json$" (base $path) "" }}
 ---

--- a/charts/varnish-gateway/templates/operator-servicemonitor.yaml
+++ b/charts/varnish-gateway/templates/operator-servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceMonitor.enabled }}
+{{- if (.Values.serviceMonitor).enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/charts/varnish-gateway/test/fixtures/values-monitoring-on.yaml
+++ b/charts/varnish-gateway/test/fixtures/values-monitoring-on.yaml
@@ -1,0 +1,8 @@
+# Exercises the ServiceMonitor / PodMonitor / dashboard ConfigMap templates
+# that are gated off by default.
+serviceMonitor:
+  enabled: true
+  labels:
+    release: prom-stack
+dashboards:
+  enabled: true

--- a/charts/varnish-gateway/test/fixtures/values-pre-monitoring.yaml
+++ b/charts/varnish-gateway/test/fixtures/values-pre-monitoring.yaml
@@ -1,0 +1,13 @@
+# Simulates `helm upgrade --reuse-values` from a release that predates the
+# `serviceMonitor` and `dashboards` top-level keys (introduced in chart 0.20.0).
+#
+# Setting them to null is the only way to exercise the nil-safe template
+# guards via `helm template`, which always merges defaults from values.yaml
+# and so cannot otherwise reproduce the missing-key state that --reuse-values
+# produces in real upgrades.
+#
+# A render against this fixture must succeed; if a future change adds a new
+# top-level key without a `(.Values.X).foo` style guard, this fixture will
+# fail with a nil-pointer error and surface the regression in CI.
+serviceMonitor: null
+dashboards: null

--- a/charts/varnish-gateway/values.schema.json
+++ b/charts/varnish-gateway/values.schema.json
@@ -1,0 +1,137 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "varnish-gateway values",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "namespace": { "type": "string", "minLength": 1 },
+    "operator": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "replicas": { "type": "integer", "minimum": 0 },
+        "image": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "repository": { "type": "string", "minLength": 1 },
+            "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] },
+            "tag": { "type": "string" }
+          }
+        },
+        "imagePullSecrets": { "type": "array" },
+        "leaderElection": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": { "enabled": { "type": "boolean" } }
+        },
+        "resources": { "type": "object" },
+        "nodeSelector": { "type": "object" },
+        "securityContext": { "type": "object" },
+        "livenessProbe": { "type": "object" },
+        "readinessProbe": { "type": "object" }
+      }
+    },
+    "gatewayClass": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "controllerName": { "type": "string", "minLength": 1 },
+        "description": { "type": "string" },
+        "createDefaultParams": { "type": "boolean" },
+        "defaultParams": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "name": { "type": "string", "minLength": 1 },
+            "userVCL": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "configMap": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {
+                    "name": { "type": "string" },
+                    "key": { "type": "string" }
+                  }
+                }
+              }
+            },
+            "logging": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "mode": { "type": "string", "enum": ["varnishlog", "varnishncsa"] },
+                "format": { "type": "string" },
+                "extraArgs": { "type": "array" }
+              }
+            },
+            "varnishdExtraArgs": {
+              "type": "array",
+              "items": { "type": "string" }
+            },
+            "extraInitContainers": { "type": "array" },
+            "extraVolumes": { "type": "array" },
+            "extraVolumeMounts": { "type": "array" }
+          }
+        }
+      }
+    },
+    "chaperone": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "image": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "repository": { "type": "string", "minLength": 1 },
+            "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] },
+            "tag": { "type": "string" }
+          }
+        },
+        "imagePullSecrets": { "type": "string" },
+        "varnishVersion": { "type": "string" }
+      }
+    },
+    "rbac": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": { "create": { "type": "boolean" } }
+    },
+    "serviceAccount": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "create": { "type": "boolean" },
+        "annotations": { "type": "object" },
+        "name": { "type": "string" }
+      }
+    },
+    "serviceMonitor": {
+      "type": ["object", "null"],
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "interval": { "type": "string", "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h)$" },
+        "scrapeTimeout": { "type": "string", "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h)$" },
+        "labels": { "type": "object" }
+      }
+    },
+    "dashboards": {
+      "type": ["object", "null"],
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "labels": { "type": "object" },
+        "annotations": { "type": "object" }
+      }
+    },
+    "commonLabels": { "type": "object" },
+    "commonAnnotations": { "type": "object" }
+  }
+}

--- a/charts/varnish-gateway/values.yaml
+++ b/charts/varnish-gateway/values.yaml
@@ -129,6 +129,13 @@ chaperone:
   # Image pull secrets for chaperone pods (comma-separated list)
   imagePullSecrets: ""
 
+  # Varnish version bundled in the chaperone image. This is the single
+  # source of truth: the Dockerfile, Makefile, and CI all read it from
+  # here. Users can template VMOD download URLs against this value and
+  # verify VMOD compatibility before upgrading. When updating, also
+  # rebuild the chaperone image and confirm `varnishd -V` matches.
+  varnishVersion: "9.0.1"
+
 # RBAC configuration
 rbac:
   # Create RBAC resources

--- a/docker/chaperone.Dockerfile
+++ b/docker/chaperone.Dockerfile
@@ -11,9 +11,13 @@ RUN CGO_ENABLED=0 go build -mod=vendor -o /chaperone ./cmd/chaperone
 
 # Stage 2: Build ghost VMOD (Rust)
 # Use debian base and install varnish + varnish-dev from the apt repo in one
-# transaction so they are always version-matched (the varnish:9.0 Docker image
-# can lag behind the apt repo, causing dependency conflicts).
+# transaction so they are always version-matched. VARNISH_VERSION is the
+# upstream major.minor.patch (e.g. 9.0.1); the apt-get glob pattern matches
+# whatever distro suffix the repo has stamped on it (e.g. 9.0.1-1~trixie).
 FROM debian:trixie-slim AS rust-builder
+
+ARG VARNISH_VERSION
+RUN test -n "${VARNISH_VERSION}" || (echo "ERROR: VARNISH_VERSION build-arg is required (read it from chaperone.varnishVersion in charts/varnish-gateway/values.yaml — \`make docker-chaperone\` does this for you)" >&2 && exit 1)
 
 RUN export DEBIAN_FRONTEND=noninteractive \
     && apt-get update \
@@ -29,7 +33,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
          build-essential pkg-config clang libclang-dev \
-         varnish varnish-dev \
+         "varnish=${VARNISH_VERSION}*" "varnish-dev=${VARNISH_VERSION}*" \
     && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.92.0 \
     && rm -rf /var/lib/apt/lists/*
 
@@ -50,6 +54,13 @@ RUN cargo build --release
 # Stage 3: Runtime image based on Debian with Varnish from apt
 FROM debian:trixie-slim
 
+ARG VARNISH_VERSION
+RUN test -n "${VARNISH_VERSION}" || (echo "ERROR: VARNISH_VERSION build-arg is required (read it from chaperone.varnishVersion in charts/varnish-gateway/values.yaml — \`make docker-chaperone\` does this for you)" >&2 && exit 1)
+
+LABEL org.opencontainers.image.title="varnish-gateway-chaperone"
+LABEL org.opencontainers.image.source="https://github.com/varnish/gateway"
+LABEL org.opencontainers.image.varnish-version="${VARNISH_VERSION}"
+
 RUN export DEBIAN_FRONTEND=noninteractive \
     && apt-get update \
     && apt-get install -y curl gpg dirmngr \
@@ -62,7 +73,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     && echo "deb [signed-by=/etc/apt/keyrings/varnish.gpg] https://packages.varnish-software.com/varnish/debian $VERSION_CODENAME main" \
          > /etc/apt/sources.list.d/varnish.list \
     && apt-get update \
-    && apt-get install -y --no-install-recommends varnish libcap2-bin \
+    && apt-get install -y --no-install-recommends "varnish=${VARNISH_VERSION}*" libcap2-bin \
     && setcap cap_ipc_lock,cap_net_bind_service+ep /usr/sbin/varnishd \
     && apt-get remove -y libcap2-bin curl gpg dirmngr && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/* ~/.gnupg \


### PR DESCRIPTION
## Summary

Closes #64 (4.1, 4.2, 4.3 plus follow-on hardening; 4.4 explicitly deferred).

- **Nil-safe new-feature values.** Wrap `serviceMonitor`/`dashboards` references with `(.Values.X).enabled` so `helm upgrade --reuse-values` from a release that predates these keys no longer crashes with `nil pointer evaluating interface {}.enabled`.
- **`values.schema.json`.** Catches type/enum errors at validate-time with clear messages instead of opaque template render failures. Tolerant of missing top-level keys (`additionalProperties: true`, none required) so it doesn't itself break `--reuse-values`.
- **Chart-test CI guard.** New `make helm-test` target lints the chart and renders it against `charts/varnish-gateway/test/fixtures/values-*.yaml` — including a `values-pre-monitoring.yaml` fixture that explicit-nulls the new top-level keys to exercise the guards. Wired into `ci.yml` as a new `helm-test` job, so any future top-level key added without a guard fails CI.
- **Pin Varnish version, single source of truth.** `chaperone.Dockerfile` requires a `VARNISH_VERSION` build-arg and installs `varnish=${VARNISH_VERSION}*` / `varnish-dev=${VARNISH_VERSION}*`. The runtime stage stamps `org.opencontainers.image.varnish-version` so the version is readable without pulling layers. The Makefile, `docker.yml` chart-publish job, and `ci.yml` test-rust job all extract the version from `chaperone.varnishVersion` in `values.yaml` — test and ship cannot drift.
- **NOTES.txt as upgrade runbook.** On `.Release.IsUpgrade`, prints the recommended `--reset-then-reuse-values --force-conflicts` incantation, the bundled Varnish version, and a link to `docs/operations/upgrades.md`. First-install path is unchanged.

### Deferred: 4.4 pre-upgrade preflight Job

Helm hook with image-pull + RBAC-bloat + stuck-release-on-transient-error semantics is the wrong shape, and largely redundant once the OCI label exists. Will revisit as either a non-blocking post-upgrade reporter or a `varnish-gateway preflight` CLI subcommand.

## Test plan

- [x] `helm lint charts/varnish-gateway` passes.
- [x] `make helm-test` passes locally (renders default + 2 fixtures).
- [x] Schema rejects `operator.replicas: "two"` and `chaperone.image.pullPolicy: Sometimes` with clear messages.
- [x] `helm template -f /tmp/values-old.yaml` (no `serviceMonitor`/`dashboards` keys) renders cleanly.
- [x] `docker buildx build --check` passes against the new Dockerfile.
- [ ] Verify `chaperone-build` and `helm-publish` jobs succeed in CI on a tag (requires merge + tag).
- [ ] Spot-check upgrade-branch NOTES.txt rendering on a real `helm upgrade` against an installed release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)