### PR TITLE
feat(operator): expose Gateway API inventory and status metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to Varnish Gateway are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Operator: Gateway API inventory and status metrics.** The operator now
+  exposes domain metrics on its existing `/metrics` endpoint (port 8080)
+  alongside the controller-runtime and client-go metrics: managed Gateway
+  count by GatewayClass (`varnish_gateway_gateways`), per-Gateway Accepted /
+  Programmed status and listener / attached-route counts
+  (`varnish_gateway_gateway_accepted`, `..._programmed`, `..._listeners`,
+  `..._attached_routes`), managed HTTPRoute totals
+  (`varnish_gateway_httproutes`, `..._httproutes_accepted`), and a build-info
+  gauge (`varnish_gateway_info`). Metrics are snapshotted from the controller
+  cache at scrape time, so deleted objects drop out with no stale series. No
+  new endpoint or ServiceMonitor is required. The Operator Grafana dashboard
+  gains an inventory/status row.
+
 ## [v0.22.0 - 2026-06-04]
 
 ### Added

--- a/charts/varnish-gateway/dashboards/operator.json
+++ b/charts/varnish-gateway/dashboards/operator.json
@@ -187,6 +187,101 @@
         "legendFormat": "{{verb}}"
       }],
       "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] }
+    },
+    {
+      "id": 40,
+      "type": "stat",
+      "title": "Gateways",
+      "description": "Number of Gateways on a GatewayClass managed by this operator.",
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 41 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [{ "expr": "sum(varnish_gateway_gateways{job=~\".*varnish-gateway-operator.*\", namespace=~\"$namespace\"})", "refId": "A" }],
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] }
+    },
+    {
+      "id": 41,
+      "type": "stat",
+      "title": "Gateways not Programmed",
+      "description": "Managed Gateways whose Programmed condition is not true. Should be 0 in steady state.",
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 41 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [{ "expr": "count(varnish_gateway_gateway_programmed{job=~\".*varnish-gateway-operator.*\", namespace=~\"$namespace\"} == 0) or vector(0)", "refId": "A" }],
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] }
+    },
+    {
+      "id": 42,
+      "type": "stat",
+      "title": "HTTPRoutes",
+      "description": "HTTPRoutes attached to a Gateway managed by this operator.",
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 41 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [{ "expr": "sum(varnish_gateway_httproutes{job=~\".*varnish-gateway-operator.*\", namespace=~\"$namespace\"})", "refId": "A" }],
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] }
+    },
+    {
+      "id": 43,
+      "type": "stat",
+      "title": "HTTPRoutes not Accepted",
+      "description": "Managed HTTPRoutes not Accepted on any parent. Should be 0 in steady state.",
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 41 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [{ "expr": "sum(varnish_gateway_httproutes{job=~\".*varnish-gateway-operator.*\", namespace=~\"$namespace\"}) - sum(varnish_gateway_httproutes_accepted{job=~\".*varnish-gateway-operator.*\", namespace=~\"$namespace\"})", "refId": "A" }],
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] }
+    },
+    {
+      "id": 50,
+      "type": "timeseries",
+      "title": "Gateways by GatewayClass",
+      "description": "varnish_gateway_gateways split by gatewayclass.",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 45 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [{
+        "expr": "sum by (gatewayclass) (varnish_gateway_gateways{job=~\".*varnish-gateway-operator.*\", namespace=~\"$namespace\"})",
+        "refId": "A",
+        "legendFormat": "{{gatewayclass}}"
+      }],
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] }
+    },
+    {
+      "id": 51,
+      "type": "timeseries",
+      "title": "Gateway Programmed status (1 = programmed)",
+      "description": "Per-Gateway Programmed condition. A line dropping to 0 means that Gateway is not programmed.",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 45 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [{
+        "expr": "varnish_gateway_gateway_programmed{job=~\".*varnish-gateway-operator.*\", namespace=~\"$namespace\"}",
+        "refId": "A",
+        "legendFormat": "{{namespace}}/{{name}}"
+      }],
+      "fieldConfig": { "defaults": { "unit": "short", "min": 0, "max": 1 }, "overrides": [] }
+    },
+    {
+      "id": 52,
+      "type": "timeseries",
+      "title": "Attached routes per Gateway",
+      "description": "varnish_gateway_gateway_attached_routes — sum of listener AttachedRoutes per Gateway.",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 53 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [{
+        "expr": "varnish_gateway_gateway_attached_routes{job=~\".*varnish-gateway-operator.*\", namespace=~\"$namespace\"}",
+        "refId": "A",
+        "legendFormat": "{{namespace}}/{{name}}"
+      }],
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] }
+    },
+    {
+      "id": 53,
+      "type": "timeseries",
+      "title": "HTTPRoutes: total vs accepted",
+      "description": "Managed HTTPRoute inventory against how many are Accepted. A persistent gap indicates routes the operator rejected.",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 53 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [
+        { "expr": "sum(varnish_gateway_httproutes{job=~\".*varnish-gateway-operator.*\", namespace=~\"$namespace\"})",          "refId": "A", "legendFormat": "total" },
+        { "expr": "sum(varnish_gateway_httproutes_accepted{job=~\".*varnish-gateway-operator.*\", namespace=~\"$namespace\"})", "refId": "B", "legendFormat": "accepted" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] }
     }
   ]
 }

--- a/charts/varnish-gateway/dashboards/operator.json
+++ b/charts/varnish-gateway/dashboards/operator.json
@@ -252,7 +252,7 @@
       "targets": [{
         "expr": "varnish_gateway_gateway_programmed{job=~\".*varnish-gateway-operator.*\", namespace=~\"$namespace\"}",
         "refId": "A",
-        "legendFormat": "{{namespace}}/{{name}}"
+        "legendFormat": "{{gateway_namespace}}/{{gateway_name}}"
       }],
       "fieldConfig": { "defaults": { "unit": "short", "min": 0, "max": 1 }, "overrides": [] }
     },
@@ -266,7 +266,7 @@
       "targets": [{
         "expr": "varnish_gateway_gateway_attached_routes{job=~\".*varnish-gateway-operator.*\", namespace=~\"$namespace\"}",
         "refId": "A",
-        "legendFormat": "{{namespace}}/{{name}}"
+        "legendFormat": "{{gateway_namespace}}/{{gateway_name}}"
       }],
       "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] }
     },

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/varnish/gateway/internal/controller"
 	"github.com/varnish/gateway/internal/k8sutil"
 	"github.com/varnish/gateway/internal/logging"
+	"github.com/varnish/gateway/internal/metrics"
 )
 
 //go:embed .version
@@ -123,6 +124,12 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Register Gateway API inventory/status metrics on controller-runtime's
+	// registry so they surface on the same /metrics endpoint. The collector
+	// reads from the manager's cache at scrape time (no live API calls).
+	metrics.RegisterGatewayMetrics(ctrlmetrics.Registry, mgr.GetClient(),
+		controller.ControllerName, strings.TrimSpace(version), logger)
+
 	// Setup GatewayClass controller
 	if err := (&controller.GatewayClassReconciler{
 		Client: mgr.GetClient(),
@@ -213,4 +220,3 @@ func getEnvOrDefault(key, defaultVal string) string {
 	}
 	return defaultVal
 }
-

--- a/docs/operations/observability.md
+++ b/docs/operations/observability.md
@@ -60,10 +60,36 @@ are exposed as Prometheus counters; all others as gauges.
 
 ### Operator metrics
 
-The operator exposes controller-runtime metrics on its own metrics
-address, port 8080 by default. These include reconciliation latency,
-work queue depth, and error counts — standard controller-runtime metrics
-documented upstream.
+The operator exposes metrics on its own metrics address, port 8080 by
+default. These fall into three groups.
+
+**Controller-runtime and client-go metrics** — reconciliation latency,
+work queue depth, error counts, and Kubernetes API request latency
+(`controller_runtime_*`, `workqueue_*`, `rest_client_*`). These are the
+standard control-plane metrics documented upstream.
+
+**Gateway API inventory and status metrics** — domain metrics describing
+the Gateway API objects the operator manages. Only objects belonging to a
+GatewayClass with our controller name are counted.
+
+#### Gauges
+
+| Metric                                    | Labels                | Description                                                        |
+| ----------------------------------------- | --------------------- | ------------------------------------------------------------------ |
+| `varnish_gateway_gateways`                | `gatewayclass`        | Number of managed Gateways, by GatewayClass                        |
+| `varnish_gateway_gateway_accepted`        | `namespace`, `name`   | 1 when the Gateway's Accepted condition is true, 0 otherwise       |
+| `varnish_gateway_gateway_programmed`      | `namespace`, `name`   | 1 when the Gateway's Programmed condition is true, 0 otherwise     |
+| `varnish_gateway_gateway_listeners`       | `namespace`, `name`   | Number of listeners configured on the Gateway                      |
+| `varnish_gateway_gateway_attached_routes` | `namespace`, `name`   | Total AttachedRoutes across all listeners of the Gateway           |
+| `varnish_gateway_httproutes`              | —                     | Number of HTTPRoutes attached to a managed Gateway                 |
+| `varnish_gateway_httproutes_accepted`     | —                     | Number of managed HTTPRoutes Accepted on at least one parent       |
+| `varnish_gateway_info`                    | `version`             | Constant 1; carries the operator build version as a label          |
+
+These are snapshotted from the controller cache at scrape time, so a
+deleted Gateway or HTTPRoute drops out of the metrics on the next scrape
+rather than lingering as a stale series. HTTPRoutes are reported as
+aggregate counts (not per-route series) to keep cardinality bounded on
+clusters with many routes.
 
 ### Prometheus scraping
 

--- a/docs/operations/observability.md
+++ b/docs/operations/observability.md
@@ -77,19 +77,27 @@ GatewayClass with our controller name are counted.
 | Metric                                    | Labels                | Description                                                        |
 | ----------------------------------------- | --------------------- | ------------------------------------------------------------------ |
 | `varnish_gateway_gateways`                | `gatewayclass`        | Number of managed Gateways, by GatewayClass                        |
-| `varnish_gateway_gateway_accepted`        | `namespace`, `name`   | 1 when the Gateway's Accepted condition is true, 0 otherwise       |
-| `varnish_gateway_gateway_programmed`      | `namespace`, `name`   | 1 when the Gateway's Programmed condition is true, 0 otherwise     |
-| `varnish_gateway_gateway_listeners`       | `namespace`, `name`   | Number of listeners configured on the Gateway                      |
-| `varnish_gateway_gateway_attached_routes` | `namespace`, `name`   | Total AttachedRoutes across all listeners of the Gateway           |
+| `varnish_gateway_gateway_accepted`        | `gateway_namespace`, `gateway_name` | 1 when the Gateway's Accepted condition is true, 0 otherwise       |
+| `varnish_gateway_gateway_programmed`      | `gateway_namespace`, `gateway_name` | 1 when the Gateway's Programmed condition is true, 0 otherwise     |
+| `varnish_gateway_gateway_listeners`       | `gateway_namespace`, `gateway_name` | Number of listeners configured on the Gateway                      |
+| `varnish_gateway_gateway_attached_routes` | `gateway_namespace`, `gateway_name` | Total AttachedRoutes across all listeners of the Gateway           |
 | `varnish_gateway_httproutes`              | —                     | Number of HTTPRoutes attached to a managed Gateway                 |
 | `varnish_gateway_httproutes_accepted`     | —                     | Number of managed HTTPRoutes Accepted on at least one parent       |
 | `varnish_gateway_info`                    | `version`             | Constant 1; carries the operator build version as a label          |
 
+The per-Gateway labels are `gateway_namespace` / `gateway_name` rather
+than `namespace` / `name` on purpose: Prometheus (and the
+prometheus-operator ServiceMonitor) attach a `namespace` label for the
+operator's own pod at scrape time, which would otherwise collide with and
+mask the Gateway object's namespace.
+
 These are snapshotted from the controller cache at scrape time, so a
 deleted Gateway or HTTPRoute drops out of the metrics on the next scrape
-rather than lingering as a stale series. HTTPRoutes are reported as
-aggregate counts (not per-route series) to keep cardinality bounded on
-clusters with many routes.
+rather than lingering as a stale series. An HTTPRoute is counted only when
+one of its `parentRefs` resolves to a Gateway this operator actually
+manages — routes pointing at a non-existent or foreign Gateway are not
+counted. HTTPRoutes are reported as aggregate counts (not per-route
+series) to keep cardinality bounded on clusters with many routes.
 
 ### Prometheus scraping
 

--- a/internal/metrics/gateway_collector.go
+++ b/internal/metrics/gateway_collector.go
@@ -57,22 +57,22 @@ func RegisterGatewayMetrics(reg prometheus.Registerer, reader client.Reader, con
 		gwAcceptedDesc: prometheus.NewDesc(
 			"varnish_gateway_gateway_accepted",
 			"Whether a managed Gateway's Accepted condition is true (1) or not (0).",
-			[]string{"namespace", "name"}, nil,
+			[]string{"gateway_namespace", "gateway_name"}, nil,
 		),
 		gwProgrammedDesc: prometheus.NewDesc(
 			"varnish_gateway_gateway_programmed",
 			"Whether a managed Gateway's Programmed condition is true (1) or not (0).",
-			[]string{"namespace", "name"}, nil,
+			[]string{"gateway_namespace", "gateway_name"}, nil,
 		),
 		gwListenersDesc: prometheus.NewDesc(
 			"varnish_gateway_gateway_listeners",
 			"Number of listeners configured on a managed Gateway.",
-			[]string{"namespace", "name"}, nil,
+			[]string{"gateway_namespace", "gateway_name"}, nil,
 		),
 		gwAttachedRoutesDesc: prometheus.NewDesc(
 			"varnish_gateway_gateway_attached_routes",
 			"Total AttachedRoutes across all listeners of a managed Gateway.",
-			[]string{"namespace", "name"}, nil,
+			[]string{"gateway_namespace", "gateway_name"}, nil,
 		),
 		httproutesDesc: prometheus.NewDesc(
 			"varnish_gateway_httproutes",
@@ -111,15 +111,23 @@ func (c *gatewayCollector) Collect(ch chan<- prometheus.Metric) {
 
 	ch <- prometheus.MustNewConstMetric(c.infoDesc, prometheus.GaugeValue, 1, c.version)
 
-	c.collectGateways(ctx, ch)
-	c.collectHTTPRoutes(ctx, ch)
+	// collectGateways returns the set of Gateways we manage so HTTPRoute
+	// counting can require an actually-attached, managed parent (a route may
+	// carry a parent status under our controller name even when the referenced
+	// Gateway does not exist — see httproute_controller processParentRef).
+	managed := c.collectGateways(ctx, ch)
+	c.collectHTTPRoutes(ctx, ch, managed)
 }
 
-func (c *gatewayCollector) collectGateways(ctx context.Context, ch chan<- prometheus.Metric) {
+// collectGateways emits per-Gateway metrics and returns the set of Gateways
+// managed by this operator, keyed by namespace/name.
+func (c *gatewayCollector) collectGateways(ctx context.Context, ch chan<- prometheus.Metric) map[client.ObjectKey]struct{} {
+	managed := make(map[client.ObjectKey]struct{})
+
 	var gwList gatewayv1.GatewayList
 	if err := c.reader.List(ctx, &gwList); err != nil {
 		c.warn("list Gateways", err)
-		return
+		return managed
 	}
 
 	// Memoize the GatewayClass -> ours? lookup so a cluster with many
@@ -139,6 +147,7 @@ func (c *gatewayCollector) collectGateways(ctx context.Context, ch chan<- promet
 			continue
 		}
 		classCounts[className]++
+		managed[client.ObjectKey{Namespace: gw.Namespace, Name: gw.Name}] = struct{}{}
 
 		ns, name := gw.Namespace, gw.Name
 		ch <- prometheus.MustNewConstMetric(c.gwAcceptedDesc, prometheus.GaugeValue,
@@ -158,25 +167,35 @@ func (c *gatewayCollector) collectGateways(ctx context.Context, ch chan<- promet
 	for className, count := range classCounts {
 		ch <- prometheus.MustNewConstMetric(c.gatewaysDesc, prometheus.GaugeValue, float64(count), className)
 	}
+
+	return managed
 }
 
-func (c *gatewayCollector) collectHTTPRoutes(ctx context.Context, ch chan<- prometheus.Metric) {
+func (c *gatewayCollector) collectHTTPRoutes(ctx context.Context, ch chan<- prometheus.Metric, managed map[client.ObjectKey]struct{}) {
 	var rtList gatewayv1.HTTPRouteList
 	if err := c.reader.List(ctx, &rtList); err != nil {
 		c.warn("list HTTPRoutes", err)
 		return
 	}
 
-	// A route is "ours" when it carries a parent status written under our
-	// controller name; that's the authoritative signal that this operator
-	// reconciled it, independent of the attachment-derivation logic in the
-	// controller package.
+	// A route counts as ours only when it carries a parent status written
+	// under our controller name AND that parent resolves to a Gateway we
+	// actually manage. The controller writes our status even for parentRefs
+	// pointing at a non-existent Gateway (NoMatchingParent), so the controller
+	// name alone would over-count routes that aren't attached to anything.
 	var total, accepted int
 	for i := range rtList.Items {
 		rt := &rtList.Items[i]
 		var mine, acc bool
 		for _, p := range rt.Status.Parents {
 			if string(p.ControllerName) != c.controllerName {
+				continue
+			}
+			ns := rt.Namespace
+			if p.ParentRef.Namespace != nil {
+				ns = string(*p.ParentRef.Namespace)
+			}
+			if _, ok := managed[client.ObjectKey{Namespace: ns, Name: string(p.ParentRef.Name)}]; !ok {
 				continue
 			}
 			mine = true

--- a/internal/metrics/gateway_collector.go
+++ b/internal/metrics/gateway_collector.go
@@ -1,0 +1,222 @@
+// Package metrics provides operator-level Prometheus collectors for the
+// Gateway API objects the operator manages. These are domain/inventory
+// metrics — how many Gateways and HTTPRoutes exist and their Accepted /
+// Programmed status — which complement (and do not duplicate) the
+// controller-runtime and client-go metrics already exposed on the same
+// metrics endpoint.
+package metrics
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/prometheus/client_golang/prometheus"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+// gatewayCollector is a prometheus.Collector that snapshots Gateway API
+// object state at scrape time. Snapshotting (rather than set-on-reconcile)
+// means deleted objects drop out of the metrics automatically, with no
+// stale-series bookkeeping — the same model gateway-api-state-metrics uses.
+//
+// Reads go through a cache-backed client (the manager's informer cache), so
+// Collect does no live API calls.
+type gatewayCollector struct {
+	reader         client.Reader
+	controllerName string
+	version        string
+	logger         *slog.Logger
+
+	gatewaysDesc           *prometheus.Desc
+	gwAcceptedDesc         *prometheus.Desc
+	gwProgrammedDesc       *prometheus.Desc
+	gwListenersDesc        *prometheus.Desc
+	gwAttachedRoutesDesc   *prometheus.Desc
+	httproutesDesc         *prometheus.Desc
+	httproutesAcceptedDesc *prometheus.Desc
+	infoDesc               *prometheus.Desc
+}
+
+// RegisterGatewayMetrics builds the Gateway API inventory collector and
+// registers it on reg. reader should be the manager's cache-backed client,
+// controllerName the operator's GatewayClass controller name (used to filter
+// to objects we manage), and version the operator build version.
+func RegisterGatewayMetrics(reg prometheus.Registerer, reader client.Reader, controllerName, version string, logger *slog.Logger) {
+	c := &gatewayCollector{
+		reader:         reader,
+		controllerName: controllerName,
+		version:        version,
+		logger:         logger,
+		gatewaysDesc: prometheus.NewDesc(
+			"varnish_gateway_gateways",
+			"Number of Gateways managed by this operator, by GatewayClass.",
+			[]string{"gatewayclass"}, nil,
+		),
+		gwAcceptedDesc: prometheus.NewDesc(
+			"varnish_gateway_gateway_accepted",
+			"Whether a managed Gateway's Accepted condition is true (1) or not (0).",
+			[]string{"namespace", "name"}, nil,
+		),
+		gwProgrammedDesc: prometheus.NewDesc(
+			"varnish_gateway_gateway_programmed",
+			"Whether a managed Gateway's Programmed condition is true (1) or not (0).",
+			[]string{"namespace", "name"}, nil,
+		),
+		gwListenersDesc: prometheus.NewDesc(
+			"varnish_gateway_gateway_listeners",
+			"Number of listeners configured on a managed Gateway.",
+			[]string{"namespace", "name"}, nil,
+		),
+		gwAttachedRoutesDesc: prometheus.NewDesc(
+			"varnish_gateway_gateway_attached_routes",
+			"Total AttachedRoutes across all listeners of a managed Gateway.",
+			[]string{"namespace", "name"}, nil,
+		),
+		httproutesDesc: prometheus.NewDesc(
+			"varnish_gateway_httproutes",
+			"Number of HTTPRoutes attached to a Gateway managed by this operator.",
+			nil, nil,
+		),
+		httproutesAcceptedDesc: prometheus.NewDesc(
+			"varnish_gateway_httproutes_accepted",
+			"Number of managed HTTPRoutes Accepted on at least one parent.",
+			nil, nil,
+		),
+		infoDesc: prometheus.NewDesc(
+			"varnish_gateway_info",
+			"Operator build info; constant 1 with the version label.",
+			[]string{"version"}, nil,
+		),
+	}
+	reg.MustRegister(c)
+}
+
+// Describe implements prometheus.Collector.
+func (c *gatewayCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.gatewaysDesc
+	ch <- c.gwAcceptedDesc
+	ch <- c.gwProgrammedDesc
+	ch <- c.gwListenersDesc
+	ch <- c.gwAttachedRoutesDesc
+	ch <- c.httproutesDesc
+	ch <- c.httproutesAcceptedDesc
+	ch <- c.infoDesc
+}
+
+// Collect implements prometheus.Collector.
+func (c *gatewayCollector) Collect(ch chan<- prometheus.Metric) {
+	ctx := context.Background()
+
+	ch <- prometheus.MustNewConstMetric(c.infoDesc, prometheus.GaugeValue, 1, c.version)
+
+	c.collectGateways(ctx, ch)
+	c.collectHTTPRoutes(ctx, ch)
+}
+
+func (c *gatewayCollector) collectGateways(ctx context.Context, ch chan<- prometheus.Metric) {
+	var gwList gatewayv1.GatewayList
+	if err := c.reader.List(ctx, &gwList); err != nil {
+		c.warn("list Gateways", err)
+		return
+	}
+
+	// Memoize the GatewayClass -> ours? lookup so a cluster with many
+	// Gateways on one class does a single Get per class per scrape.
+	classIsOurs := make(map[string]bool)
+	classCounts := make(map[string]int)
+
+	for i := range gwList.Items {
+		gw := &gwList.Items[i]
+		className := string(gw.Spec.GatewayClassName)
+		ours, seen := classIsOurs[className]
+		if !seen {
+			ours = c.isOurClass(ctx, className)
+			classIsOurs[className] = ours
+		}
+		if !ours {
+			continue
+		}
+		classCounts[className]++
+
+		ns, name := gw.Namespace, gw.Name
+		ch <- prometheus.MustNewConstMetric(c.gwAcceptedDesc, prometheus.GaugeValue,
+			boolToFloat(apimeta.IsStatusConditionTrue(gw.Status.Conditions, string(gatewayv1.GatewayConditionAccepted))), ns, name)
+		ch <- prometheus.MustNewConstMetric(c.gwProgrammedDesc, prometheus.GaugeValue,
+			boolToFloat(apimeta.IsStatusConditionTrue(gw.Status.Conditions, string(gatewayv1.GatewayConditionProgrammed))), ns, name)
+		ch <- prometheus.MustNewConstMetric(c.gwListenersDesc, prometheus.GaugeValue,
+			float64(len(gw.Spec.Listeners)), ns, name)
+
+		var attached int32
+		for _, l := range gw.Status.Listeners {
+			attached += l.AttachedRoutes
+		}
+		ch <- prometheus.MustNewConstMetric(c.gwAttachedRoutesDesc, prometheus.GaugeValue, float64(attached), ns, name)
+	}
+
+	for className, count := range classCounts {
+		ch <- prometheus.MustNewConstMetric(c.gatewaysDesc, prometheus.GaugeValue, float64(count), className)
+	}
+}
+
+func (c *gatewayCollector) collectHTTPRoutes(ctx context.Context, ch chan<- prometheus.Metric) {
+	var rtList gatewayv1.HTTPRouteList
+	if err := c.reader.List(ctx, &rtList); err != nil {
+		c.warn("list HTTPRoutes", err)
+		return
+	}
+
+	// A route is "ours" when it carries a parent status written under our
+	// controller name; that's the authoritative signal that this operator
+	// reconciled it, independent of the attachment-derivation logic in the
+	// controller package.
+	var total, accepted int
+	for i := range rtList.Items {
+		rt := &rtList.Items[i]
+		var mine, acc bool
+		for _, p := range rt.Status.Parents {
+			if string(p.ControllerName) != c.controllerName {
+				continue
+			}
+			mine = true
+			if apimeta.IsStatusConditionTrue(p.Conditions, string(gatewayv1.RouteConditionAccepted)) {
+				acc = true
+			}
+		}
+		if mine {
+			total++
+			if acc {
+				accepted++
+			}
+		}
+	}
+
+	ch <- prometheus.MustNewConstMetric(c.httproutesDesc, prometheus.GaugeValue, float64(total))
+	ch <- prometheus.MustNewConstMetric(c.httproutesAcceptedDesc, prometheus.GaugeValue, float64(accepted))
+}
+
+// isOurClass reports whether className is a GatewayClass with our controllerName.
+func (c *gatewayCollector) isOurClass(ctx context.Context, className string) bool {
+	if className == "" {
+		return false
+	}
+	var gc gatewayv1.GatewayClass
+	if err := c.reader.Get(ctx, client.ObjectKey{Name: className}, &gc); err != nil {
+		return false
+	}
+	return string(gc.Spec.ControllerName) == c.controllerName
+}
+
+func (c *gatewayCollector) warn(msg string, err error) {
+	if c.logger != nil {
+		c.logger.Warn("gateway metrics collection failed", "step", msg, "error", err)
+	}
+}
+
+func boolToFloat(b bool) float64 {
+	if b {
+		return 1
+	}
+	return 0
+}

--- a/internal/metrics/gateway_collector_test.go
+++ b/internal/metrics/gateway_collector_test.go
@@ -1,0 +1,191 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+const testController = "varnish-software.com/gateway"
+
+func testScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatalf("clientgoscheme.AddToScheme: %v", err)
+	}
+	if err := gatewayv1.Install(scheme); err != nil {
+		t.Fatalf("gatewayv1.Install: %v", err)
+	}
+	return scheme
+}
+
+func acceptedCond(condType string, status metav1.ConditionStatus) metav1.Condition {
+	return metav1.Condition{Type: condType, Status: status, Reason: "Test", LastTransitionTime: metav1.Now()}
+}
+
+func TestGatewayCollector(t *testing.T) {
+	scheme := testScheme(t)
+
+	objs := []client.Object{
+		// Our GatewayClass and a foreign one.
+		&gatewayv1.GatewayClass{
+			ObjectMeta: metav1.ObjectMeta{Name: "varnish"},
+			Spec:       gatewayv1.GatewayClassSpec{ControllerName: testController},
+		},
+		&gatewayv1.GatewayClass{
+			ObjectMeta: metav1.ObjectMeta{Name: "other"},
+			Spec:       gatewayv1.GatewayClassSpec{ControllerName: "someone/else"},
+		},
+		// gw1: ours, Accepted+Programmed, 2 listeners, 3 attached routes.
+		&gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{Name: "gw1", Namespace: "default"},
+			Spec: gatewayv1.GatewaySpec{
+				GatewayClassName: "varnish",
+				Listeners: []gatewayv1.Listener{
+					{Name: "l1", Protocol: gatewayv1.HTTPProtocolType, Port: 80},
+					{Name: "l2", Protocol: gatewayv1.HTTPSProtocolType, Port: 443},
+				},
+			},
+			Status: gatewayv1.GatewayStatus{
+				Conditions: []metav1.Condition{
+					acceptedCond(string(gatewayv1.GatewayConditionAccepted), metav1.ConditionTrue),
+					acceptedCond(string(gatewayv1.GatewayConditionProgrammed), metav1.ConditionTrue),
+				},
+				Listeners: []gatewayv1.ListenerStatus{
+					{Name: "l1", AttachedRoutes: 3},
+					{Name: "l2", AttachedRoutes: 0},
+				},
+			},
+		},
+		// gw2: ours, Accepted but not Programmed, 1 listener, 1 attached route.
+		&gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{Name: "gw2", Namespace: "prod"},
+			Spec: gatewayv1.GatewaySpec{
+				GatewayClassName: "varnish",
+				Listeners:        []gatewayv1.Listener{{Name: "l1", Protocol: gatewayv1.HTTPProtocolType, Port: 80}},
+			},
+			Status: gatewayv1.GatewayStatus{
+				Conditions: []metav1.Condition{
+					acceptedCond(string(gatewayv1.GatewayConditionAccepted), metav1.ConditionTrue),
+					acceptedCond(string(gatewayv1.GatewayConditionProgrammed), metav1.ConditionFalse),
+				},
+				Listeners: []gatewayv1.ListenerStatus{{Name: "l1", AttachedRoutes: 1}},
+			},
+		},
+		// gw3: foreign GatewayClass — must be excluded.
+		&gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{Name: "gw3", Namespace: "default"},
+			Spec:       gatewayv1.GatewaySpec{GatewayClassName: "other"},
+		},
+		// r1: ours, Accepted.
+		&gatewayv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{Name: "r1", Namespace: "default"},
+			Status: gatewayv1.HTTPRouteStatus{RouteStatus: gatewayv1.RouteStatus{Parents: []gatewayv1.RouteParentStatus{{
+				ParentRef:      gatewayv1.ParentReference{Name: "gw1"},
+				ControllerName: testController,
+				Conditions:     []metav1.Condition{acceptedCond(string(gatewayv1.RouteConditionAccepted), metav1.ConditionTrue)},
+			}}}},
+		},
+		// r2: ours, not Accepted.
+		&gatewayv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{Name: "r2", Namespace: "default"},
+			Status: gatewayv1.HTTPRouteStatus{RouteStatus: gatewayv1.RouteStatus{Parents: []gatewayv1.RouteParentStatus{{
+				ParentRef:      gatewayv1.ParentReference{Name: "gw1"},
+				ControllerName: testController,
+				Conditions:     []metav1.Condition{acceptedCond(string(gatewayv1.RouteConditionAccepted), metav1.ConditionFalse)},
+			}}}},
+		},
+		// r3: reconciled by a foreign controller — must be excluded.
+		&gatewayv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{Name: "r3", Namespace: "default"},
+			Status: gatewayv1.HTTPRouteStatus{RouteStatus: gatewayv1.RouteStatus{Parents: []gatewayv1.RouteParentStatus{{
+				ParentRef:      gatewayv1.ParentReference{Name: "somegw"},
+				ControllerName: "someone/else",
+				Conditions:     []metav1.Condition{acceptedCond(string(gatewayv1.RouteConditionAccepted), metav1.ConditionTrue)},
+			}}}},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+
+	reg := prometheus.NewRegistry()
+	RegisterGatewayMetrics(reg, c, testController, "v1.2.3", nil)
+
+	fams, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Gather: %v", err)
+	}
+
+	checks := []struct {
+		name   string
+		labels map[string]string
+		want   float64
+	}{
+		{"varnish_gateway_info", map[string]string{"version": "v1.2.3"}, 1},
+		{"varnish_gateway_gateways", map[string]string{"gatewayclass": "varnish"}, 2},
+		{"varnish_gateway_gateway_accepted", map[string]string{"namespace": "default", "name": "gw1"}, 1},
+		{"varnish_gateway_gateway_programmed", map[string]string{"namespace": "default", "name": "gw1"}, 1},
+		{"varnish_gateway_gateway_programmed", map[string]string{"namespace": "prod", "name": "gw2"}, 0},
+		{"varnish_gateway_gateway_listeners", map[string]string{"namespace": "default", "name": "gw1"}, 2},
+		{"varnish_gateway_gateway_attached_routes", map[string]string{"namespace": "default", "name": "gw1"}, 3},
+		{"varnish_gateway_gateway_attached_routes", map[string]string{"namespace": "prod", "name": "gw2"}, 1},
+		{"varnish_gateway_httproutes", map[string]string{}, 2},
+		{"varnish_gateway_httproutes_accepted", map[string]string{}, 1},
+	}
+
+	for _, tc := range checks {
+		got, ok := findGauge(fams, tc.name, tc.labels)
+		if !ok {
+			t.Errorf("%s%v: metric not found", tc.name, tc.labels)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("%s%v = %v, want %v", tc.name, tc.labels, got, tc.want)
+		}
+	}
+
+	// The foreign GatewayClass must not appear.
+	if _, ok := findGauge(fams, "varnish_gateway_gateways", map[string]string{"gatewayclass": "other"}); ok {
+		t.Error("varnish_gateway_gateways emitted a series for a foreign GatewayClass")
+	}
+	// gw3 (foreign class) must not produce per-Gateway series.
+	if _, ok := findGauge(fams, "varnish_gateway_gateway_accepted", map[string]string{"namespace": "default", "name": "gw3"}); ok {
+		t.Error("gw3 (foreign GatewayClass) produced a per-Gateway series")
+	}
+}
+
+// findGauge returns the value of the gauge named name whose label set exactly
+// equals labels, and whether such a series exists.
+func findGauge(fams []*dto.MetricFamily, name string, labels map[string]string) (float64, bool) {
+	for _, fam := range fams {
+		if fam.GetName() != name {
+			continue
+		}
+		for _, m := range fam.GetMetric() {
+			if labelsEqual(m, labels) {
+				return m.GetGauge().GetValue(), true
+			}
+		}
+	}
+	return 0, false
+}
+
+func labelsEqual(m *dto.Metric, want map[string]string) bool {
+	if len(m.GetLabel()) != len(want) {
+		return false
+	}
+	for _, lp := range m.GetLabel() {
+		if want[lp.GetName()] != lp.GetValue() {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/metrics/gateway_collector_test.go
+++ b/internal/metrics/gateway_collector_test.go
@@ -112,6 +112,17 @@ func TestGatewayCollector(t *testing.T) {
 				Conditions:     []metav1.Condition{acceptedCond(string(gatewayv1.RouteConditionAccepted), metav1.ConditionTrue)},
 			}}}},
 		},
+		// r4: our controller name, but parentRef points at a Gateway that does
+		// not exist. The controller writes this status (NoMatchingParent), yet
+		// the route is not attached to any managed Gateway — must be excluded.
+		&gatewayv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{Name: "r4", Namespace: "default"},
+			Status: gatewayv1.HTTPRouteStatus{RouteStatus: gatewayv1.RouteStatus{Parents: []gatewayv1.RouteParentStatus{{
+				ParentRef:      gatewayv1.ParentReference{Name: "ghost-gw"},
+				ControllerName: testController,
+				Conditions:     []metav1.Condition{acceptedCond(string(gatewayv1.RouteConditionAccepted), metav1.ConditionFalse)},
+			}}}},
+		},
 	}
 
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
@@ -131,12 +142,12 @@ func TestGatewayCollector(t *testing.T) {
 	}{
 		{"varnish_gateway_info", map[string]string{"version": "v1.2.3"}, 1},
 		{"varnish_gateway_gateways", map[string]string{"gatewayclass": "varnish"}, 2},
-		{"varnish_gateway_gateway_accepted", map[string]string{"namespace": "default", "name": "gw1"}, 1},
-		{"varnish_gateway_gateway_programmed", map[string]string{"namespace": "default", "name": "gw1"}, 1},
-		{"varnish_gateway_gateway_programmed", map[string]string{"namespace": "prod", "name": "gw2"}, 0},
-		{"varnish_gateway_gateway_listeners", map[string]string{"namespace": "default", "name": "gw1"}, 2},
-		{"varnish_gateway_gateway_attached_routes", map[string]string{"namespace": "default", "name": "gw1"}, 3},
-		{"varnish_gateway_gateway_attached_routes", map[string]string{"namespace": "prod", "name": "gw2"}, 1},
+		{"varnish_gateway_gateway_accepted", map[string]string{"gateway_namespace": "default", "gateway_name": "gw1"}, 1},
+		{"varnish_gateway_gateway_programmed", map[string]string{"gateway_namespace": "default", "gateway_name": "gw1"}, 1},
+		{"varnish_gateway_gateway_programmed", map[string]string{"gateway_namespace": "prod", "gateway_name": "gw2"}, 0},
+		{"varnish_gateway_gateway_listeners", map[string]string{"gateway_namespace": "default", "gateway_name": "gw1"}, 2},
+		{"varnish_gateway_gateway_attached_routes", map[string]string{"gateway_namespace": "default", "gateway_name": "gw1"}, 3},
+		{"varnish_gateway_gateway_attached_routes", map[string]string{"gateway_namespace": "prod", "gateway_name": "gw2"}, 1},
 		{"varnish_gateway_httproutes", map[string]string{}, 2},
 		{"varnish_gateway_httproutes_accepted", map[string]string{}, 1},
 	}
@@ -157,7 +168,7 @@ func TestGatewayCollector(t *testing.T) {
 		t.Error("varnish_gateway_gateways emitted a series for a foreign GatewayClass")
 	}
 	// gw3 (foreign class) must not produce per-Gateway series.
-	if _, ok := findGauge(fams, "varnish_gateway_gateway_accepted", map[string]string{"namespace": "default", "name": "gw3"}); ok {
+	if _, ok := findGauge(fams, "varnish_gateway_gateway_accepted", map[string]string{"gateway_namespace": "default", "gateway_name": "gw3"}); ok {
 		t.Error("gw3 (foreign GatewayClass) produced a per-Gateway series")
 	}
 }


### PR DESCRIPTION
Add a prometheus.Collector that snapshots Gateway API object state at scrape time and emits varnish_gateway_* domain metrics on the operator's existing /metrics endpoint (registered on controller-runtime's registry, so no new endpoint, Service, or ServiceMonitor is needed):

- varnish_gateway_gateways{gatewayclass}
- varnish_gateway_gateway_accepted / _programmed / _listeners / _attached_routes{namespace,name}
- varnish_gateway_httproutes / _httproutes_accepted
- varnish_gateway_info{version}

Reads go through the manager cache (no live API calls), and only objects on a GatewayClass with our controller name are counted. Snapshotting avoids the stale-series problem of set-on-reconcile gauges. HTTPRoutes are aggregate counts to bound cardinality.

Also extends the Operator Grafana dashboard with an inventory/status row and documents the new metrics in the observability guide.
