### PR TITLE
fix(ci): update stale run_vtc_tests filter to vtc_

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,10 +101,10 @@ jobs:
         run: cd ghost && cargo build --release
 
       - name: Run Rust unit tests in release mode
-        run: cd ghost && cargo test --release --lib
+        run: cd ghost && cargo test --release --lib -- --skip vtc_
 
       - name: Run VTC integration tests
-        run: cd ghost && cargo test --release run_vtc_tests
+        run: cd ghost && cargo test --release vtc_
 
   helm-test:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -232,8 +232,8 @@ build-ghost:
 test-ghost:
 	cd ghost && cargo clippy --release -- -D warnings
 	cd ghost && cargo build --release
-	cd ghost && LD_LIBRARY_PATH=$$(pwd)/target/release cargo test --release --lib
-	cd ghost && LD_LIBRARY_PATH=$$(pwd)/target/release VARNISHTEST_DURATION=8s cargo test --release run_vtc_tests
+	cd ghost && LD_LIBRARY_PATH=$$(pwd)/target/release cargo test --release --lib -- --skip vtc_
+	cd ghost && LD_LIBRARY_PATH=$$(pwd)/target/release VARNISHTEST_DURATION=8s cargo test --release vtc_
 
 # ============================================================================
 # Docker images

--- a/ghost/CLAUDE.md
+++ b/ghost/CLAUDE.md
@@ -69,10 +69,10 @@ docker build -f docker/chaperone.Dockerfile -t varnish-gateway .
 
 ```bash
 # Unit tests (work in debug and release mode)
-cargo test --lib -- --skip run_vtc_tests
+cargo test --lib -- --skip vtc_
 
 # VTC integration tests (must use release mode - see DEBUG_MODE_LIMITATIONS.md)
-cargo test --release run_vtc_tests
+cargo test --release vtc_
 
 # All tests in release mode (recommended)
 cargo test --release


### PR DESCRIPTION
The varnish crate 0.7 upgrade (75968c4) renamed the tests generated by `run_vtc_tests!` from a single `run_vtc_tests` function to per-file `vtc_*` tests, so the CI/Make filters drifted stale.

- `ci.yml`, `Makefile`, and `ghost/CLAUDE.md` still filtered on `run_vtc_tests` — matches nothing, runs 0 tests, and exits 0 (green).
- Coverage wasn't actually lost: the unit-test step (`--lib`, no skip) ran everything including the 17 VTC tests, so the two steps overlapped and the dedicated VTC step was dead weight.
- Fix makes each step run what its name says: unit step `--lib -- --skip vtc_` (75 tests), VTC step `vtc_` (17 tests).

Verified against varnishd 9.0.3: 75 unit + 17 VTC, all passing.

## Proof

The old filter is branch-independent — typing `vtc_` matches the 17 tests on any branch, so a hand-typed filter can't show the fix. What changed is the filter baked into the CI files. Running both on this branch shows it:

```
$ cargo test --release run_vtc_tests 2>&1 | grep -E 'running|test result'   # old (dead) filter
running 0 tests
test result: ok. 0 passed; 0 failed; ... 92 filtered out

$ cargo test --release vtc_ 2>&1 | grep -E 'running|test result'            # new filter
running 17 tests
test result: ok. 17 passed; 0 failed; ...
```

<!-- Screenshot: the two commands above run back-to-back on this branch — 0 tests vs 17 passed. -->
