### PR TITLE
fix: resolve all 10 high-severity code-review findings

### DIFF
--- a/cmd/chaperone/main.go
+++ b/cmd/chaperone/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"crypto/subtle"
 	_ "embed"
 	"errors"
 	"fmt"
@@ -68,7 +69,15 @@ type Config struct {
 	TLSListen  []string // -a arguments for HTTPS (e.g., "https=:8443,https")
 
 	// Health endpoint
-	HealthAddr string // address for health endpoint
+	HealthAddr string // address for health endpoint (pod interface; kubelet probes it)
+
+	// Debug endpoint (pprof + backend.list). Bound to loopback only; reached
+	// via kubectl port-forward. kubelet does not need it.
+	DebugAddr string
+
+	// DrainToken is the shared secret required (via the X-Drain-Token header)
+	// to invoke /drain. Empty disables the endpoint entirely.
+	DrainToken string
 
 	// Dashboard (optional, empty = disabled)
 	DashboardAddr string // address for dashboard UI
@@ -99,6 +108,8 @@ func loadConfig() (*Config, error) {
 		TLSCertDir:        os.Getenv("TLS_CERT_DIR"),                  // empty by default
 		TLSListen:         parseList(os.Getenv("VARNISH_TLS_LISTEN")), // empty by default
 		HealthAddr:        getEnvOrDefault("HEALTH_ADDR", ":8080"),
+		DebugAddr:         getEnvOrDefault("DEBUG_ADDR", "127.0.0.1:6060"),
+		DrainToken:        os.Getenv("DRAIN_TOKEN"),    // empty = /drain disabled
 		DashboardAddr:     os.Getenv("DASHBOARD_ADDR"), // empty = disabled
 		GatewayName:       os.Getenv("GATEWAY_NAME"),
 		PodName:           os.Getenv("POD_NAME"),
@@ -371,23 +382,46 @@ func run() error {
 	k8sutil.RegisterClientGoMetrics(promReg)
 	chapMetrics := newChaperoneMetrics(promReg)
 
-	// Start health server with drain endpoint for graceful shutdown
+	// Health server: bound to the pod interface because the kubelet reaches
+	// the readiness probe (/health) and the preStop hook (/drain) via the pod
+	// IP, and Prometheus scrapes /metrics. /drain is token-gated so a peer pod
+	// cannot drain the gateway with a single unauthenticated request.
 	mux := http.NewServeMux()
 	mux.HandleFunc("/health", makeHealthHandler(dashState))
-	mux.HandleFunc("/drain", makeDrainHandler(dashState))
-	mux.HandleFunc("/debug/backends", makeBackendsHandler(vadm))
+	mux.HandleFunc("/drain", makeDrainHandler(dashState, cfg.DrainToken))
 	mux.Handle("/metrics", promhttp.HandlerFor(promReg, promhttp.HandlerOpts{}))
-	// pprof on the same mux. Service is ClusterIP-only; chaos soaks fetch
-	// profiles via kubectl proxy when a slope threshold trips.
-	mux.HandleFunc("/debug/pprof/", pprof.Index)
-	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
-	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
-	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
-	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
 
 	healthServer := &http.Server{
 		Addr:    cfg.HealthAddr,
 		Handler: mux,
+		// Health/metrics/drain requests are all small and fast, so cap every
+		// phase to defend against Slowloris-style slow-header/body attacks.
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		WriteTimeout:      30 * time.Second,
+		IdleTimeout:       120 * time.Second,
+	}
+
+	// Debug server: pprof + backend.list, bound to loopback only. These carry
+	// no auth and are diagnostic, so they must not be exposed on the pod
+	// interface. Reach them with `kubectl port-forward`, which forwards into
+	// the pod netns and can connect to 127.0.0.1.
+	debugMux := http.NewServeMux()
+	debugMux.HandleFunc("/debug/backends", makeBackendsHandler(vadm))
+	debugMux.HandleFunc("/debug/pprof/", pprof.Index)
+	debugMux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	debugMux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	debugMux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	debugMux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
+	debugServer := &http.Server{
+		Addr:    cfg.DebugAddr,
+		Handler: debugMux,
+		// pprof profile/trace stream for their full duration (default 30s and
+		// up), so leave WriteTimeout unbounded. ReadHeaderTimeout + IdleTimeout
+		// still bound header stalls and idle keep-alives.
+		ReadHeaderTimeout: 5 * time.Second,
+		IdleTimeout:       120 * time.Second,
 	}
 
 	// Start all components concurrently using errgroup.
@@ -472,6 +506,24 @@ func run() error {
 		<-gctx.Done()
 		if err := healthServer.Close(); err != nil {
 			slog.Error("health server close failed", "error", err)
+		}
+		return nil
+	})
+
+	// Debug server (loopback-only: pprof + backend.list)
+	g.Go(func() error {
+		slog.Debug("debug server starting", "addr", cfg.DebugAddr)
+		if err := debugServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			return fmt.Errorf("debugServer.ListenAndServe: %w", err)
+		}
+		return nil
+	})
+
+	// Shutdown debug server when context is cancelled
+	g.Go(func() error {
+		<-gctx.Done()
+		if err := debugServer.Close(); err != nil {
+			slog.Error("debug server close failed", "error", err)
 		}
 		return nil
 	})
@@ -580,8 +632,30 @@ func makeHealthHandler(state *dashboard.StateTracker) http.HandlerFunc {
 	}
 }
 
-func makeDrainHandler(state *dashboard.StateTracker) http.HandlerFunc {
+// makeDrainHandler returns the /drain handler. Draining flips readiness to 503,
+// so it must be authenticated: without a token, any pod that can reach the pod
+// interface could take the gateway out of rotation with a single request.
+//
+// The endpoint lives on the pod interface (not loopback) because the kubelet
+// invokes it from the preStop lifecycle hook against the pod IP. The shared
+// token — supplied by the operator via both the DRAIN_TOKEN env var and the
+// preStop hook's X-Drain-Token header — is the access control. The kubelet
+// HTTPGet lifecycle handler can only issue GET, so we cannot additionally
+// require POST here; the token alone closes the cross-pod DoS.
+func makeDrainHandler(state *dashboard.StateTracker, token string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		if token == "" {
+			// No token configured: refuse rather than drain on any request.
+			slog.Warn("drain requested but DRAIN_TOKEN is unset; refusing")
+			http.Error(w, "drain endpoint disabled", http.StatusForbidden)
+			return
+		}
+		provided := r.Header.Get("X-Drain-Token")
+		if subtle.ConstantTimeCompare([]byte(provided), []byte(token)) != 1 {
+			slog.Warn("drain requested with missing or invalid token; rejecting", "remote", r.RemoteAddr)
+			http.Error(w, "forbidden", http.StatusForbidden)
+			return
+		}
 		state.SetDraining()
 		slog.Info("drain requested via endpoint, health will now return 503")
 		w.WriteHeader(http.StatusOK)

--- a/cmd/chaperone/main_test.go
+++ b/cmd/chaperone/main_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/varnish/gateway/internal/dashboard"
+)
+
+// newTestState returns a StateTracker marked ready (not draining).
+func newTestState() *dashboard.StateTracker {
+	bus := dashboard.NewEventBus(16)
+	st := dashboard.NewStateTracker(bus, "test")
+	st.SetReady()
+	return st
+}
+
+func TestDrainHandler_ValidToken(t *testing.T) {
+	st := newTestState()
+	h := makeDrainHandler(st, "s3cr3t")
+
+	req := httptest.NewRequest(http.MethodGet, "/drain", nil)
+	req.Header.Set("X-Drain-Token", "s3cr3t")
+	rec := httptest.NewRecorder()
+	h(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if !st.IsDraining() {
+		t.Fatal("expected draining state after valid drain request")
+	}
+}
+
+func TestDrainHandler_MissingToken(t *testing.T) {
+	st := newTestState()
+	h := makeDrainHandler(st, "s3cr3t")
+
+	req := httptest.NewRequest(http.MethodGet, "/drain", nil)
+	rec := httptest.NewRecorder()
+	h(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", rec.Code)
+	}
+	if st.IsDraining() {
+		t.Fatal("gateway drained despite missing token (cross-pod DoS not closed)")
+	}
+}
+
+func TestDrainHandler_WrongToken(t *testing.T) {
+	st := newTestState()
+	h := makeDrainHandler(st, "s3cr3t")
+
+	req := httptest.NewRequest(http.MethodGet, "/drain", nil)
+	req.Header.Set("X-Drain-Token", "guessed")
+	rec := httptest.NewRecorder()
+	h(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", rec.Code)
+	}
+	if st.IsDraining() {
+		t.Fatal("gateway drained despite wrong token")
+	}
+}
+
+// When no token is configured the endpoint must refuse rather than drain on
+// any request.
+func TestDrainHandler_EmptyTokenDisabled(t *testing.T) {
+	st := newTestState()
+	h := makeDrainHandler(st, "")
+
+	req := httptest.NewRequest(http.MethodGet, "/drain", nil)
+	rec := httptest.NewRecorder()
+	h(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", rec.Code)
+	}
+	if st.IsDraining() {
+		t.Fatal("gateway drained with no token configured")
+	}
+}

--- a/ghost/src/lib.rs
+++ b/ghost/src/lib.rs
@@ -218,7 +218,12 @@ mod ghost {
                 not_found: not_found_backend,
                 redirect: redirect_backend,
                 internal_error: internal_error_backend,
-            } = GhostDirectorBundle::new(ctx, Arc::new(empty_directors), backend_pool, config_path)?;
+            } = GhostDirectorBundle::new(
+                ctx,
+                Arc::new(empty_directors),
+                backend_pool,
+                config_path,
+            )?;
 
             // Pre-load config if the file already exists on disk.
             // On initial startup the file won't exist yet (chaperone hasn't
@@ -282,17 +287,22 @@ mod ghost {
             // The postamble vcl_recv checks this header and calls return(pass).
             if result.pass {
                 if let Some(req) = ctx.http_req.as_mut() {
+                    // Must unset first since set_header() appends a header slot.
+                    req.unset_header("X-Ghost-Pass");
                     let _ = req.set_header("X-Ghost-Pass", "true");
                 }
             }
 
             // Set X-Gateway-Listener and X-Gateway-Route headers for user VCL
-            // Re-borrow req from ctx since the previous borrow ended after route_request
+            // Re-borrow req from ctx since the previous borrow ended after route_request.
+            // Must unset first since set_header() appends a header slot.
             if let Some(req) = ctx.http_req.as_mut() {
                 if let Some(ref listener) = listener_owned {
+                    req.unset_header("X-Gateway-Listener");
                     let _ = req.set_header("X-Gateway-Listener", listener);
                 }
                 if let Some(ref name) = result.route_name {
+                    req.unset_header("X-Gateway-Route");
                     let _ = req.set_header("X-Gateway-Route", name);
                 }
             }
@@ -358,14 +368,8 @@ mod test_stubs {
     pub unsafe extern "C" fn VRT_DelDirector(_bp: *mut *const c_void) {}
 
     #[no_mangle]
-    pub unsafe extern "C" fn VRT_delete_backend(
-        _ctx: *const c_void,
-        _bp: *mut *const c_void,
-    ) {}
+    pub unsafe extern "C" fn VRT_delete_backend(_ctx: *const c_void, _bp: *mut *const c_void) {}
 
     #[no_mangle]
-    pub unsafe extern "C" fn VRT_Assign_Backend(
-        _dst: *mut *const c_void,
-        _src: *const c_void,
-    ) {}
+    pub unsafe extern "C" fn VRT_Assign_Backend(_dst: *mut *const c_void, _src: *const c_void) {}
 }

--- a/ghost/src/redirect_backend.rs
+++ b/ghost/src/redirect_backend.rs
@@ -50,6 +50,11 @@ impl VclBackend<RedirectBody> for RedirectBackend {
             e
         })?;
 
+        // Validate the redirect status against the Gateway API allowed set.
+        // The config header is internal, but defence-in-depth: never emit an
+        // arbitrary status. Fall back to 302 Found for out-of-range values.
+        let status_code = sanitize_redirect_status(config.filter.status_code);
+
         // Set response status and Location header
         {
             let beresp = ctx
@@ -57,7 +62,7 @@ impl VclBackend<RedirectBody> for RedirectBackend {
                 .as_mut()
                 .ok_or_else(|| VclError::new("Missing beresp in redirect backend".to_string()))?;
 
-            beresp.set_status(config.filter.status_code as u16);
+            beresp.set_status(status_code);
             beresp.set_header("Location", &location)?;
             beresp.set_header("Cache-Control", "no-store")?;
         }
@@ -73,10 +78,19 @@ impl VclBackend<RedirectBody> for RedirectBackend {
 
         ctx.log(
             LogTag::Debug,
-            format!("Redirect {} -> {}", config.filter.status_code, location),
+            format!("Redirect {} -> {}", status_code, location),
         );
 
         Ok(Some(RedirectBody::new()))
+    }
+}
+
+/// Clamp a redirect status code to the Gateway API allowed set
+/// ({301, 302, 303, 307, 308}), falling back to 302 Found otherwise.
+fn sanitize_redirect_status(status_code: u16) -> u16 {
+    match status_code {
+        301 | 302 | 303 | 307 | 308 => status_code,
+        _ => 302,
     }
 }
 
@@ -414,6 +428,19 @@ mod tests {
 
         let result = rewrite_path(&filter, "/v1", Some("/v1")).unwrap();
         assert_eq!(result, "/v2");
+    }
+
+    #[test]
+    fn test_sanitize_redirect_status() {
+        // Allowed Gateway API redirect codes pass through unchanged.
+        for code in [301, 302, 303, 307, 308] {
+            assert_eq!(sanitize_redirect_status(code), code);
+        }
+        // Out-of-range / spoofed values fall back to 302.
+        assert_eq!(sanitize_redirect_status(200), 302);
+        assert_eq!(sanitize_redirect_status(500), 302);
+        assert_eq!(sanitize_redirect_status(0), 302);
+        assert_eq!(sanitize_redirect_status(999), 302);
     }
 
     #[test]

--- a/ghost/src/vhost_director.rs
+++ b/ghost/src/vhost_director.rs
@@ -108,12 +108,9 @@ impl VhostDirector {
     /// Check if this director has any routes with backends or filters
     /// Routes with redirect filters but no backends are considered "healthy"
     fn has_backends(&self) -> bool {
-        self.routes.iter().any(|r| {
-            r.backend_groups
-                .iter()
-                .any(|g| !g.backends.is_empty())
-                || r.filters.is_some()
-        })
+        self.routes
+            .iter()
+            .any(|r| r.backend_groups.iter().any(|g| !g.backends.is_empty()) || r.filters.is_some())
     }
 
     /// Collect all backend keys used by this director
@@ -270,7 +267,12 @@ impl VhostDirector {
             listener,
         ) {
             Some(r) => r,
-            None => return RouteRequestResult { log_msgs, ..Default::default() },
+            None => {
+                return RouteRequestResult {
+                    log_msgs,
+                    ..Default::default()
+                }
+            }
         };
         let backend_groups = match_result.backend_groups;
         let matched_filters = match_result.filters.as_ref();
@@ -280,7 +282,10 @@ impl VhostDirector {
         if let Some(filters) = matched_filters {
             // RequestRedirect - takes precedence over all other filters
             if let Some(redirect_filter) = &filters.request_redirect {
-                log_msgs.push((LogTag::Debug, "Applying request redirect filter".to_string()));
+                log_msgs.push((
+                    LogTag::Debug,
+                    "Applying request redirect filter".to_string(),
+                ));
 
                 // Extract original request components
                 let (original_scheme, original_hostname, original_port) = {
@@ -301,8 +306,7 @@ impl VhostDirector {
                         "http"
                     };
 
-                    let port =
-                        port_opt.unwrap_or_else(|| if scheme == "https" { 443 } else { 80 });
+                    let port = port_opt.unwrap_or_else(|| if scheme == "https" { 443 } else { 80 });
 
                     (scheme.to_string(), hostname.to_string(), port)
                 };
@@ -339,6 +343,8 @@ impl VhostDirector {
                     }
                 };
 
+                // Must unset first since set_header() appends a header slot.
+                http.unset_header("X-Ghost-Redirect-Config");
                 if let Err(e) = http.set_header("X-Ghost-Redirect-Config", &config_json) {
                     log_msgs.push((
                         LogTag::Error,
@@ -403,12 +409,14 @@ impl VhostDirector {
         // Look up in backend pool
         let entry = match self.backend_pool.get(backend_key) {
             Some(e) => e,
-            None => return RouteRequestResult {
-                backend: None,
-                route_name,
-                log_msgs,
-                pass,
-            },
+            None => {
+                return RouteRequestResult {
+                    backend: None,
+                    route_name,
+                    log_msgs,
+                    pass,
+                }
+            }
         };
 
         RouteRequestResult {
@@ -569,19 +577,25 @@ fn apply_cache_policy_headers(
         }
     }
 
-    // Set TTL headers (bridge to vcl_backend_response via bereq)
+    // Set TTL headers (bridge to vcl_backend_response via bereq).
+    // Must unset first since set_header() appends a header slot.
     if let Some(ttl) = cache_policy.default_ttl_seconds {
+        http.unset_header("X-Ghost-Default-TTL");
         let _ = http.set_header("X-Ghost-Default-TTL", &format!("{}s", ttl));
     }
     if let Some(ttl) = cache_policy.forced_ttl_seconds {
+        http.unset_header("X-Ghost-Forced-TTL");
         let _ = http.set_header("X-Ghost-Forced-TTL", &format!("{}s", ttl));
     }
 
-    // Set grace and keep (bridge to vcl_backend_response via bereq)
+    // Set grace and keep (bridge to vcl_backend_response via bereq).
+    // Must unset first since set_header() appends a header slot.
     if cache_policy.grace_seconds > 0 {
+        http.unset_header("X-Ghost-Grace");
         let _ = http.set_header("X-Ghost-Grace", &format!("{}s", cache_policy.grace_seconds));
     }
     if cache_policy.keep_seconds > 0 {
+        http.unset_header("X-Ghost-Keep");
         let _ = http.set_header("X-Ghost-Keep", &format!("{}s", cache_policy.keep_seconds));
     }
 
@@ -615,6 +629,8 @@ fn apply_cache_policy_headers(
         }
 
         if !extra_parts.is_empty() {
+            // Must unset first since set_header() appends a header slot.
+            http.unset_header("X-Ghost-Cache-Key-Extra");
             let _ = http.set_header("X-Ghost-Cache-Key-Extra", &extra_parts.join("|"));
         }
     }
@@ -733,7 +749,6 @@ fn extract_path_and_query(url: &str) -> (&str, Option<&str>) {
         (final_path, None)
     }
 }
-
 
 fn apply_request_header_filter(
     http: &mut HttpHeaders,
@@ -1005,11 +1020,16 @@ fn parse_host_and_port(host_header: &str) -> (&str, Option<u16>) {
     (host_header, None)
 }
 
-fn store_filter_context(http: &mut HttpHeaders, filters: &Arc<RouteFilters>) -> Result<(), VclError> {
+fn store_filter_context(
+    http: &mut HttpHeaders,
+    filters: &Arc<RouteFilters>,
+) -> Result<(), VclError> {
     // Serialize response filter to JSON
     if let Some(resp_filter) = &filters.response_header_modifier {
         let json = serde_json::to_string(resp_filter)
             .map_err(|e| VclError::new(format!("serialize filter: {}", e)))?;
+        // Must unset first since set_header() appends a header slot.
+        http.unset_header(FILTER_CONTEXT_HEADER);
         http.set_header(FILTER_CONTEXT_HEADER, &json)?;
     }
 
@@ -1056,17 +1076,11 @@ mod tests {
         let groups = vec![
             WeightedBackendGroup {
                 weight: 90,
-                backends: vec![
-                    "10.0.0.1:8080".to_string(),
-                    "10.0.0.2:8080".to_string(),
-                ],
+                backends: vec!["10.0.0.1:8080".to_string(), "10.0.0.2:8080".to_string()],
             },
             WeightedBackendGroup {
                 weight: 10,
-                backends: vec![
-                    "10.0.0.3:8080".to_string(),
-                    "10.0.0.4:8080".to_string(),
-                ],
+                backends: vec!["10.0.0.3:8080".to_string(), "10.0.0.4:8080".to_string()],
             },
         ];
 
@@ -1106,10 +1120,7 @@ mod tests {
         // Single group with 2 pods — should distribute ~50/50
         let groups = vec![WeightedBackendGroup {
             weight: 100,
-            backends: vec![
-                "10.0.0.1:8080".to_string(),
-                "10.0.0.2:8080".to_string(),
-            ],
+            backends: vec!["10.0.0.1:8080".to_string(), "10.0.0.2:8080".to_string()],
         }];
 
         let mut counts = HashMap::new();

--- a/internal/controller/gateway_controller.go
+++ b/internal/controller/gateway_controller.go
@@ -18,12 +18,14 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/util/workqueue"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -1735,57 +1737,87 @@ func gatewayHasCrossNSCertRefTo(gateway *gatewayv1.Gateway, targetNamespace stri
 	return false
 }
 
+// gatewayRequestsForRoute returns reconcile requests for the Gateways (managed by
+// our GatewayClass) referenced by the given route's parentRefs, deduplicated.
+func (r *GatewayReconciler) gatewayRequestsForRoute(ctx context.Context, route *gatewayv1.HTTPRoute) []ctrl.Request {
+	var requests []ctrl.Request
+	seen := make(map[types.NamespacedName]bool)
+
+	for _, parentRef := range route.Spec.ParentRefs {
+		// Skip non-Gateway refs
+		if parentRef.Kind != nil && *parentRef.Kind != "Gateway" {
+			continue
+		}
+		if parentRef.Group != nil && *parentRef.Group != gatewayv1.Group(gatewayv1.GroupName) {
+			continue
+		}
+
+		// Determine namespace
+		namespace := route.Namespace
+		if parentRef.Namespace != nil {
+			namespace = string(*parentRef.Namespace)
+		}
+
+		nn := types.NamespacedName{
+			Name:      string(parentRef.Name),
+			Namespace: namespace,
+		}
+		if seen[nn] {
+			continue
+		}
+		seen[nn] = true
+
+		// Verify the Gateway uses our GatewayClass before enqueuing
+		var gw gatewayv1.Gateway
+		if err := r.Get(ctx, nn, &gw); err != nil {
+			continue
+		}
+		if !isOurGatewayClass(ctx, r.Client, string(gw.Spec.GatewayClassName)) {
+			continue
+		}
+
+		requests = append(requests, ctrl.Request{NamespacedName: nn})
+	}
+
+	return requests
+}
+
 // enqueueGatewaysForHTTPRoute returns an EventHandler that enqueues Gateways
-// referenced by a changed HTTPRoute. This allows the Gateway controller to
-// update AttachedRoutes counts when routes are created, updated, or deleted.
+// referenced by a changed HTTPRoute. This allows the Gateway controller to update
+// AttachedRoutes counts when routes are created, updated, or deleted.
+//
+// On update it enqueues BOTH the old and new parent Gateways. Without the old
+// parents, a route that changes its parentRefs (edited sectionName, moved from
+// Gateway A to Gateway B, or dropped to zero) would leave the previous Gateway
+// never reconciled — its AttachedRoutes count (and, via the HTTPRoute controller,
+// its routing.json) would stay stale indefinitely.
 func (r *GatewayReconciler) enqueueGatewaysForHTTPRoute() handler.EventHandler {
-	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []ctrl.Request {
+	enqueue := func(ctx context.Context, obj client.Object, q workqueue.TypedRateLimitingInterface[ctrl.Request]) {
 		route, ok := obj.(*gatewayv1.HTTPRoute)
 		if !ok {
-			return nil
+			return
 		}
-
-		var requests []ctrl.Request
-		seen := make(map[types.NamespacedName]bool)
-
-		for _, parentRef := range route.Spec.ParentRefs {
-			// Skip non-Gateway refs
-			if parentRef.Kind != nil && *parentRef.Kind != "Gateway" {
-				continue
-			}
-			if parentRef.Group != nil && *parentRef.Group != gatewayv1.Group(gatewayv1.GroupName) {
-				continue
-			}
-
-			// Determine namespace
-			namespace := route.Namespace
-			if parentRef.Namespace != nil {
-				namespace = string(*parentRef.Namespace)
-			}
-
-			nn := types.NamespacedName{
-				Name:      string(parentRef.Name),
-				Namespace: namespace,
-			}
-			if seen[nn] {
-				continue
-			}
-			seen[nn] = true
-
-			// Verify the Gateway uses our GatewayClass before enqueuing
-			var gw gatewayv1.Gateway
-			if err := r.Get(ctx, nn, &gw); err != nil {
-				continue
-			}
-			if !isOurGatewayClass(ctx, r.Client, string(gw.Spec.GatewayClassName)) {
-				continue
-			}
-
-			requests = append(requests, ctrl.Request{NamespacedName: nn})
+		for _, req := range r.gatewayRequestsForRoute(ctx, route) {
+			q.Add(req)
 		}
+	}
 
-		return requests
-	})
+	return handler.Funcs{
+		CreateFunc: func(ctx context.Context, e event.CreateEvent, q workqueue.TypedRateLimitingInterface[ctrl.Request]) {
+			enqueue(ctx, e.Object, q)
+		},
+		UpdateFunc: func(ctx context.Context, e event.UpdateEvent, q workqueue.TypedRateLimitingInterface[ctrl.Request]) {
+			// Enqueue old and new parents; the workqueue deduplicates overlaps.
+			enqueue(ctx, e.ObjectOld, q)
+			enqueue(ctx, e.ObjectNew, q)
+		},
+		DeleteFunc: func(ctx context.Context, e event.DeleteEvent, q workqueue.TypedRateLimitingInterface[ctrl.Request]) {
+			enqueue(ctx, e.Object, q)
+		},
+		GenericFunc: func(ctx context.Context, e event.GenericEvent, q workqueue.TypedRateLimitingInterface[ctrl.Request]) {
+			enqueue(ctx, e.Object, q)
+		},
+	}
 }
 
 // enqueueGatewaysForBackendTLSPolicy returns an EventHandler that enqueues

--- a/internal/controller/gateway_controller_test.go
+++ b/internal/controller/gateway_controller_test.go
@@ -3436,6 +3436,46 @@ func TestEnqueueGatewaysForHTTPRoute(t *testing.T) {
 			t.Errorf("expected 0 requests, got %d", len(requests))
 		}
 	})
+
+	t.Run("update moving route A->B enqueues both old and new gateways", func(t *testing.T) {
+		gwA := &gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{Name: "gw-a", Namespace: "default"},
+			Spec:       gatewayv1.GatewaySpec{GatewayClassName: "varnish"},
+		}
+		gwB := &gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{Name: "gw-b", Namespace: "default"},
+			Spec:       gatewayv1.GatewaySpec{GatewayClassName: "varnish"},
+		}
+		r := newTestReconciler(scheme, gwA, gwB)
+		h := r.enqueueGatewaysForHTTPRoute()
+
+		oldRoute := &gatewayv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{Name: "route", Namespace: "default"},
+			Spec: gatewayv1.HTTPRouteSpec{CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{{Name: "gw-a"}},
+			}},
+		}
+		newRoute := &gatewayv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{Name: "route", Namespace: "default"},
+			Spec: gatewayv1.HTTPRouteSpec{CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{{Name: "gw-b"}},
+			}},
+		}
+
+		q := &fakeQueue{}
+		h.Update(ctx, event.UpdateEvent{ObjectOld: oldRoute, ObjectNew: newRoute}, q)
+
+		got := map[string]bool{}
+		for _, req := range q.requests {
+			got[req.Name] = true
+		}
+		if !got["gw-a"] {
+			t.Error("expected old parent gw-a to be enqueued (so its stale routing/AttachedRoutes are refreshed)")
+		}
+		if !got["gw-b"] {
+			t.Error("expected new parent gw-b to be enqueued")
+		}
+	})
 }
 
 // ============================================================

--- a/internal/controller/httproute_controller.go
+++ b/internal/controller/httproute_controller.go
@@ -60,9 +60,38 @@ func (r *HTTPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		}
 		return ctrl.Result{}, fmt.Errorf("r.Get(%s): %w", req.NamespacedName, err)
 	}
-	// 2. Skip if no parentRefs
+	// Capture the Gateways this route was previously programmed onto (from its
+	// existing status) BEFORE we mutate status below. Comparing against the
+	// current parentRefs lets us regenerate routing.json for Gateways the route
+	// has since detached from (edited parentRefs, moved A→B, or dropped to zero).
+	previousGateways := gatewaysFromRouteStatus(&route)
+	currentGateways := gatewaysFromRouteSpec(&route)
+
+	// 2. Handle routes with no parentRefs.
 	if len(route.Spec.ParentRefs) == 0 {
-		log.Debug("HTTPRoute has no parentRefs, skipping")
+		log.Debug("HTTPRoute has no parentRefs")
+		// The route detached from every parent. Regenerate any Gateways we
+		// previously programmed it onto so its stale routing.json entries are
+		// removed. currentGateways is empty, so all previous parents are detached.
+		if err := r.regenerateDetachedGateways(ctx, previousGateways, currentGateways); err != nil {
+			log.Error("failed to regenerate detached gateways", "error", err)
+			return ctrl.Result{}, err
+		}
+		// Drop our now-stale status.Parents entries (currentGateways is empty).
+		if len(previousGateways) > 0 {
+			pruneDetachedRouteParents(&route, currentGateways)
+			routeStatus := route.Status
+			if err := r.Get(ctx, req.NamespacedName, &route); err != nil {
+				if apierrors.IsNotFound(err) {
+					return ctrl.Result{}, nil
+				}
+				return ctrl.Result{}, fmt.Errorf("r.Get (re-fetch for status): %w", err)
+			}
+			route.Status = routeStatus
+			if err := r.Status().Update(ctx, &route); err != nil {
+				return ctrl.Result{}, fmt.Errorf("r.Status().Update: %w", err)
+			}
+		}
 		return ctrl.Result{}, nil
 	}
 
@@ -80,6 +109,15 @@ func (r *HTTPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			processErr = err
 		}
 	}
+
+	// 3b. Regenerate routing.json for Gateways the route has detached from
+	// (present in the previous status but not in the current parentRefs), and
+	// prune their stale status.Parents entries.
+	if err := r.regenerateDetachedGateways(ctx, previousGateways, currentGateways); err != nil {
+		log.Error("failed to regenerate detached gateways", "error", err)
+		processErr = err
+	}
+	pruneDetachedRouteParents(&route, currentGateways)
 
 	// 4. Update HTTPRoute status
 	// Re-fetch the route to get the latest resourceVersion before updating status.
@@ -300,71 +338,125 @@ func listAcceptedRoutesForGateway(ctx context.Context, c client.Client, gateway 
 	return attached, nil
 }
 
+// parentRefTargetsGateway reports whether a single parentRef references the given
+// Gateway (correct Kind/Group, name, and namespace). It does NOT apply
+// sectionName/port or AllowedRoutes policy — that is layered on by callers.
+func parentRefTargetsGateway(parentRef *gatewayv1.ParentReference, route *gatewayv1.HTTPRoute, gateway *gatewayv1.Gateway) bool {
+	// Skip non-Gateway refs
+	if parentRef.Kind != nil && *parentRef.Kind != "Gateway" {
+		return false
+	}
+	// Check group (default to gateway.networking.k8s.io)
+	if parentRef.Group != nil && *parentRef.Group != gatewayv1.Group(gatewayv1.GroupName) {
+		return false
+	}
+	// Check name
+	if string(parentRef.Name) != gateway.Name {
+		return false
+	}
+	// Check namespace (default to route's namespace)
+	refNamespace := route.Namespace
+	if parentRef.Namespace != nil {
+		refNamespace = string(*parentRef.Namespace)
+	}
+	return refNamespace == gateway.Namespace
+}
+
 // routeAttachedToGateway checks if a route references the given Gateway (package-level).
 func routeAttachedToGateway(route *gatewayv1.HTTPRoute, gateway *gatewayv1.Gateway) bool {
-	for _, parentRef := range route.Spec.ParentRefs {
-		// Skip non-Gateway refs
-		if parentRef.Kind != nil && *parentRef.Kind != "Gateway" {
-			continue
+	for i := range route.Spec.ParentRefs {
+		if parentRefTargetsGateway(&route.Spec.ParentRefs[i], route, gateway) {
+			return true
 		}
-
-		// Check name
-		if string(parentRef.Name) != gateway.Name {
-			continue
-		}
-
-		// Check namespace
-		refNamespace := route.Namespace
-		if parentRef.Namespace != nil {
-			refNamespace = string(*parentRef.Namespace)
-		}
-		if refNamespace != gateway.Namespace {
-			continue
-		}
-
-		// Check group (default to gateway.networking.k8s.io)
-		if parentRef.Group != nil && *parentRef.Group != gatewayv1.Group(gatewayv1.GroupName) {
-			continue
-		}
-
-		return true
 	}
 	return false
 }
 
-// isRouteAllowedByGateway checks if the route is allowed by any of the Gateway's listeners (package-level).
-// A route is allowed if at least one listener:
-// 1. Allows the route's namespace (per AllowedRoutes policy)
-// 2. Has hostname intersection with the route (or either has no hostname)
-// Returns (true, "", "") if any listener allows the route, or (false, reasonCode, message) if none do.
-// The reasonCode distinguishes between NotAllowedByListeners and NoMatchingListenerHostname.
+// listenerAttachment records the outcome of computing which of a Gateway's
+// listeners a route validly attaches to.
+type listenerAttachment struct {
+	// listenerNames is the deduplicated set of listener names the route attaches
+	// to: for each parentRef, candidate listeners are restricted by sectionName/port,
+	// then MUST individually satisfy the listener's AllowedRoutes namespace policy
+	// AND have a hostname intersection with the route. This is the union of passing
+	// (parentRef × listener) pairs.
+	listenerNames []string
+	// namespaceAllowed is true if at least one candidate listener allowed the
+	// route's namespace (even if the hostname did not intersect). It distinguishes
+	// NotAllowedByListeners (no listener allowed the namespace) from
+	// NoMatchingListenerHostname (namespace allowed, hostname mismatch).
+	namespaceAllowed bool
+}
+
+// computeListenerAttachment computes, per listener, whether a route validly
+// attaches to a Gateway. Unlike a whole-Gateway "any listener allows it" check,
+// this enforces the AllowedRoutes namespace policy AND hostname intersection on
+// the SAME listener, restricted per parentRef by sectionName/port. The resulting
+// listenerNames set is the authoritative attachment used both for the Accepted
+// status and for the socket set programmed into routing.json — closing the
+// per-listener namespace bypass where a foreign-namespace route could be served on
+// a from:Same listener merely because some other listener allowed it.
+func computeListenerAttachment(ctx context.Context, c client.Reader, route *gatewayv1.HTTPRoute, gateway *gatewayv1.Gateway) listenerAttachment {
+	var att listenerAttachment
+	seen := make(map[string]bool)
+
+	for i := range route.Spec.ParentRefs {
+		parentRef := &route.Spec.ParentRefs[i]
+		if !parentRefTargetsGateway(parentRef, route, gateway) {
+			continue
+		}
+
+		for j := range gateway.Spec.Listeners {
+			listener := &gateway.Spec.Listeners[j]
+
+			// Restrict candidate listeners by this parentRef's sectionName/port.
+			if parentRef.SectionName != nil && string(listener.Name) != string(*parentRef.SectionName) {
+				continue
+			}
+			if parentRef.Port != nil && listener.Port != *parentRef.Port {
+				continue
+			}
+
+			// Namespace policy MUST hold on this specific listener.
+			allowed, err := listenerAllowsRouteNamespace(ctx, c, route, gateway, *listener)
+			if err != nil || !allowed {
+				continue
+			}
+			att.namespaceAllowed = true
+
+			// Hostname intersection MUST hold on this same listener.
+			if !hostnamesIntersect(route.Spec.Hostnames, listener.Hostname) {
+				continue
+			}
+
+			if !seen[string(listener.Name)] {
+				seen[string(listener.Name)] = true
+				att.listenerNames = append(att.listenerNames, string(listener.Name))
+			}
+		}
+	}
+
+	return att
+}
+
+// isRouteAllowedByGateway checks if the route validly attaches to at least one of
+// the Gateway's listeners (package-level). Per-listener, a route must satisfy BOTH
+// the AllowedRoutes namespace policy AND a hostname intersection on the same
+// listener. Returns (true, "", "") when at least one listener passes, or
+// (false, reasonCode, message) otherwise. The reasonCode distinguishes between
+// NotAllowedByListeners and NoMatchingListenerHostname.
 func isRouteAllowedByGateway(ctx context.Context, c client.Reader, route *gatewayv1.HTTPRoute, gateway *gatewayv1.Gateway) (bool, string, string) {
 	if len(gateway.Spec.Listeners) == 0 {
 		return false, string(gatewayv1.RouteReasonNotAllowedByListeners), "Gateway has no listeners"
 	}
 
-	namespaceAllowed := false
-	for _, listener := range gateway.Spec.Listeners {
-		// Check namespace policy
-		allowed, err := listenerAllowsRouteNamespace(ctx, c, route, gateway, listener)
-		if err != nil {
-			continue
-		}
-		if !allowed {
-			continue
-		}
-		namespaceAllowed = true
-
-		// Check hostname intersection
-		if !hostnamesIntersect(route.Spec.Hostnames, listener.Hostname) {
-			continue
-		}
-
+	att := computeListenerAttachment(ctx, c, route, gateway)
+	if len(att.listenerNames) > 0 {
 		return true, "", ""
 	}
 
-	if namespaceAllowed {
-		// Namespace was allowed by at least one listener, but hostnames didn't intersect
+	if att.namespaceAllowed {
+		// A listener allowed the namespace, but no allowed listener's hostname intersected.
 		return false, string(gatewayv1.RouteReasonNoMatchingListenerHostname),
 			fmt.Sprintf("No matching listener hostname on Gateway %s/%s", gateway.Namespace, gateway.Name)
 	}
@@ -409,48 +501,60 @@ func listenerAllowsRouteNamespace(ctx context.Context, c client.Reader, route *g
 }
 
 // effectiveHostnames computes the set of effective hostnames for a route against
-// the gateway's listeners filtered by sectionName and/or port. This is the intersection of
-// route hostnames with listener hostnames, producing the most specific hostname
-// from each match pair.
+// the gateway's listeners filtered by sectionName and/or port. This is the
+// intersection of route hostnames with listener hostnames, producing the most
+// specific hostname from each match pair.
+//
 // If sectionName is non-nil, only listeners matching that name are considered.
 // If port is non-nil, only listeners matching that port are considered.
-func effectiveHostnames(route *gatewayv1.HTTPRoute, gateway *gatewayv1.Gateway, sectionName *gatewayv1.SectionName, port *gatewayv1.PortNumber) []gatewayv1.Hostname {
+// If allowedNames is non-nil, only listeners whose name is in the set are
+// considered — this restricts hostnames to listeners that actually passed the
+// per-listener namespace policy, keeping the emitted hostname set consistent with
+// the programmed socket set.
+//
+// The second return value reports whether the match is a genuine catch-all: a
+// route with no hostnames attaching to a listener with no hostname. This is
+// distinct from "no hostnames intersected" (empty slice, false) and from
+// "sectionName/port/allowedNames matched no listener" (empty slice, false); those
+// cases mean this parentRef contributes nothing, NOT that the route serves all
+// hostnames.
+func effectiveHostnames(route *gatewayv1.HTTPRoute, gateway *gatewayv1.Gateway, sectionName *gatewayv1.SectionName, port *gatewayv1.PortNumber, allowedNames map[string]bool) ([]gatewayv1.Hostname, bool) {
 	routeHostnames := route.Spec.Hostnames
 
-	// Collect listener hostnames, filtered by sectionName and/or port if specified
+	// Collect listener hostnames, filtered by sectionName, port, and allowedNames.
 	var listenerHostnames []*gatewayv1.Hostname
 	for i := range gateway.Spec.Listeners {
-		if sectionName != nil && string(gateway.Spec.Listeners[i].Name) != string(*sectionName) {
+		l := &gateway.Spec.Listeners[i]
+		if sectionName != nil && string(l.Name) != string(*sectionName) {
 			continue
 		}
-		if port != nil && gateway.Spec.Listeners[i].Port != *port {
+		if port != nil && l.Port != *port {
 			continue
 		}
-		listenerHostnames = append(listenerHostnames, gateway.Spec.Listeners[i].Hostname)
+		if allowedNames != nil && !allowedNames[string(l.Name)] {
+			continue
+		}
+		listenerHostnames = append(listenerHostnames, l.Hostname)
 	}
 
-	// If route has no hostnames and any listener has no hostname, result is catch-all
-	// If route has no hostnames, effective hostnames are the listener hostnames
+	// Route with no hostnames: effective hostnames are the listener hostnames,
+	// unless a candidate listener also has no hostname — then it is a genuine
+	// catch-all and the route serves all hostnames.
 	if len(routeHostnames) == 0 {
 		seen := make(map[string]bool)
 		var result []gatewayv1.Hostname
 		for _, lh := range listenerHostnames {
 			if lh == nil {
-				// Catch-all: route with no hostnames + listener with no hostname
-				if !seen["*"] {
-					seen["*"] = true
-					// Return empty to signal catch-all (CollectHTTPRouteBackends handles this)
-					return nil
-				}
-			} else {
-				h := string(*lh)
-				if !seen[h] {
-					seen[h] = true
-					result = append(result, gatewayv1.Hostname(h))
-				}
+				// Genuine catch-all: route with no hostnames + listener with no hostname.
+				return nil, true
+			}
+			h := string(*lh)
+			if !seen[h] {
+				seen[h] = true
+				result = append(result, gatewayv1.Hostname(h))
 			}
 		}
-		return result
+		return result, false
 	}
 
 	// Route has hostnames - intersect each with each listener hostname
@@ -476,7 +580,7 @@ func effectiveHostnames(route *gatewayv1.HTTPRoute, gateway *gatewayv1.Gateway, 
 		}
 	}
 
-	return result
+	return result, false
 }
 
 // computeEffectiveHostname returns the most specific hostname from the intersection
@@ -523,40 +627,52 @@ func computeEffectiveHostname(routeHostname, listenerHostname string) string {
 }
 
 // filterRouteHostnames returns copies of routes with hostnames filtered to only
-// those that intersect with the gateway's listeners. Each route's parentRefs are
-// inspected to determine which listener(s) it targets via sectionName, so that
-// a route targeting listener-1 only gets hostnames from that listener.
-func filterRouteHostnames(routes []gatewayv1.HTTPRoute, gateway *gatewayv1.Gateway) []gatewayv1.HTTPRoute {
+// those that intersect with the gateway's listeners the route validly attaches to.
+// Each route's parentRefs are inspected to determine which listener(s) it targets
+// via sectionName/port, and attachments restricts consideration to listeners that
+// passed the per-listener namespace policy — so a route only gets hostnames from
+// listeners it is actually permitted (and programmed) to serve on.
+//
+// attachments maps a route key ("namespace/name") to its computed listener
+// attachment. A route whose key is absent falls back to no allowed-name filtering.
+func filterRouteHostnames(routes []gatewayv1.HTTPRoute, gateway *gatewayv1.Gateway, attachments map[string]listenerAttachment) []gatewayv1.HTTPRoute {
 	filtered := make([]gatewayv1.HTTPRoute, 0, len(routes))
 	for i := range routes {
+		key := routes[i].Namespace + "/" + routes[i].Name
+
+		// Restrict to listeners that passed the per-listener namespace policy.
+		var allowedNames map[string]bool
+		if att, ok := attachments[key]; ok {
+			allowedNames = make(map[string]bool, len(att.listenerNames))
+			for _, n := range att.listenerNames {
+				allowedNames[n] = true
+			}
+		}
+
 		// Collect effective hostnames across all parentRefs targeting this gateway.
 		// A route may have multiple parentRefs with different sectionNames.
 		seen := make(map[string]bool)
 		var allEffective []gatewayv1.Hostname
 		isCatchAll := false
 
-		for _, parentRef := range routes[i].Spec.ParentRefs {
-			// Skip non-Gateway refs
-			if parentRef.Kind != nil && *parentRef.Kind != "Gateway" {
-				continue
-			}
-			// Check this parentRef targets the given gateway
-			if string(parentRef.Name) != gateway.Name {
-				continue
-			}
-			refNS := routes[i].Namespace
-			if parentRef.Namespace != nil {
-				refNS = string(*parentRef.Namespace)
-			}
-			if refNS != gateway.Namespace {
+		for j := range routes[i].Spec.ParentRefs {
+			parentRef := &routes[i].Spec.ParentRefs[j]
+			if !parentRefTargetsGateway(parentRef, &routes[i], gateway) {
 				continue
 			}
 
-			effective := effectiveHostnames(&routes[i], gateway, parentRef.SectionName, parentRef.Port)
-			if effective == nil {
-				// Catch-all from this parentRef
+			effective, catchAll := effectiveHostnames(&routes[i], gateway, parentRef.SectionName, parentRef.Port, allowedNames)
+			if catchAll {
+				// Genuine catch-all: the route serves all hostnames. This is a
+				// superset of anything other parentRefs could contribute.
 				isCatchAll = true
 				break
+			}
+			if len(effective) == 0 {
+				// No hostname intersection from this parentRef (or it matched no
+				// permitted listener). It contributes nothing — skip it, but do NOT
+				// discard hostnames contributed by other parentRefs.
+				continue
 			}
 			// Apply listener isolation: remove hostnames claimed by more specific listeners
 			if parentRef.SectionName != nil {
@@ -576,7 +692,8 @@ func filterRouteHostnames(routes []gatewayv1.HTTPRoute, gateway *gatewayv1.Gatew
 			continue
 		}
 		if len(allEffective) == 0 {
-			// No intersection - skip this route entirely
+			// No intersection from any parentRef and not a genuine catch-all -
+			// skip this route entirely rather than programming its full hostname set.
 			continue
 		}
 		// Create a copy with only the intersecting hostnames
@@ -589,8 +706,22 @@ func filterRouteHostnames(routes []gatewayv1.HTTPRoute, gateway *gatewayv1.Gatew
 
 // updateConfigMap updates the Gateway's ConfigMap with routing.json (preserves main.vcl).
 func (r *HTTPRouteReconciler) updateConfigMap(ctx context.Context, gateway *gatewayv1.Gateway, routes []gatewayv1.HTTPRoute) error {
-	// Filter route hostnames to only those intersecting with gateway listeners
-	filteredRoutes := filterRouteHostnames(routes, gateway)
+	// Compute the authoritative per-listener attachment for each route once. This
+	// enforces the AllowedRoutes namespace policy AND hostname intersection on the
+	// same listener, and drives both the emitted hostname set and the socket set —
+	// so a route is only ever programmed onto listeners it is truly permitted on.
+	attachments := make(map[string]listenerAttachment, len(routes))
+	routeListeners := make(map[string][]string, len(routes))
+	for i := range routes {
+		key := routes[i].Namespace + "/" + routes[i].Name
+		att := computeListenerAttachment(ctx, r.Client, &routes[i], gateway)
+		attachments[key] = att
+		routeListeners[key] = att.listenerNames
+	}
+
+	// Filter route hostnames to only those intersecting with the listeners the
+	// route validly attaches to.
+	filteredRoutes := filterRouteHostnames(routes, gateway, attachments)
 
 	// Build port map to resolve service ports to target ports
 	portMap := r.buildServicePortMap(ctx, filteredRoutes, gateway.Namespace)
@@ -598,8 +729,9 @@ func (r *HTTPRouteReconciler) updateConfigMap(ctx context.Context, gateway *gate
 	// Compute blocked cross-namespace backend refs (not permitted by ReferenceGrants)
 	blockedRefs := r.computeBlockedBackendRefs(ctx, filteredRoutes)
 
-	// Generate routing.json for ghost with path-based routing
-	collectedRoutes := vcl.CollectHTTPRouteBackends(filteredRoutes, gateway, gateway.Namespace, portMap, blockedRefs)
+	// Generate routing.json for ghost with path-based routing. routeListeners
+	// supplies the authoritative socket set per route (respecting namespace policy).
+	collectedRoutes := vcl.CollectHTTPRouteBackends(filteredRoutes, gateway, gateway.Namespace, portMap, blockedRefs, routeListeners)
 
 	// Attach VarnishCachePolicy to each route
 	r.attachCachePolicies(ctx, collectedRoutes, filteredRoutes, gateway)
@@ -927,6 +1059,112 @@ func (r *HTTPRouteReconciler) buildServicePortMap(ctx context.Context, routes []
 		}
 	}
 	return portMap
+}
+
+// gatewaysFromRouteSpec returns the set of Gateways (our group) currently
+// referenced by the route's parentRefs, keyed by NamespacedName.
+func gatewaysFromRouteSpec(route *gatewayv1.HTTPRoute) map[types.NamespacedName]bool {
+	result := make(map[types.NamespacedName]bool)
+	for i := range route.Spec.ParentRefs {
+		pr := &route.Spec.ParentRefs[i]
+		if pr.Kind != nil && *pr.Kind != "Gateway" {
+			continue
+		}
+		if pr.Group != nil && *pr.Group != gatewayv1.Group(gatewayv1.GroupName) {
+			continue
+		}
+		ns := route.Namespace
+		if pr.Namespace != nil {
+			ns = string(*pr.Namespace)
+		}
+		result[types.NamespacedName{Name: string(pr.Name), Namespace: ns}] = true
+	}
+	return result
+}
+
+// gatewaysFromRouteStatus returns the set of Gateways this controller previously
+// programmed the route onto, derived from the route's existing status.Parents
+// entries owned by our ControllerName. Used to detect parents the route has since
+// detached from.
+func gatewaysFromRouteStatus(route *gatewayv1.HTTPRoute) map[types.NamespacedName]bool {
+	result := make(map[types.NamespacedName]bool)
+	for _, ps := range route.Status.Parents {
+		if string(ps.ControllerName) != ControllerName {
+			continue
+		}
+		pr := ps.ParentRef
+		if pr.Kind != nil && *pr.Kind != "Gateway" {
+			continue
+		}
+		if pr.Group != nil && *pr.Group != gatewayv1.Group(gatewayv1.GroupName) {
+			continue
+		}
+		ns := route.Namespace
+		if pr.Namespace != nil {
+			ns = string(*pr.Namespace)
+		}
+		result[types.NamespacedName{Name: string(pr.Name), Namespace: ns}] = true
+	}
+	return result
+}
+
+// pruneDetachedRouteParents removes RouteParentStatus entries owned by our
+// controller whose Gateway is no longer referenced by the route's spec (the
+// `current` set). Entries owned by other controllers, and entries for still-current
+// Gateways, are preserved.
+func pruneDetachedRouteParents(route *gatewayv1.HTTPRoute, current map[types.NamespacedName]bool) {
+	kept := make([]gatewayv1.RouteParentStatus, 0, len(route.Status.Parents))
+	for _, ps := range route.Status.Parents {
+		if string(ps.ControllerName) == ControllerName {
+			pr := ps.ParentRef
+			isGateway := pr.Kind == nil || *pr.Kind == "Gateway"
+			isOurGroup := pr.Group == nil || *pr.Group == gatewayv1.Group(gatewayv1.GroupName)
+			if isGateway && isOurGroup {
+				ns := route.Namespace
+				if pr.Namespace != nil {
+					ns = string(*pr.Namespace)
+				}
+				nn := types.NamespacedName{Name: string(pr.Name), Namespace: ns}
+				if !current[nn] {
+					continue // drop stale entry for a detached Gateway
+				}
+			}
+		}
+		kept = append(kept, ps)
+	}
+	route.Status.Parents = kept
+}
+
+// regenerateDetachedGateways regenerates routing.json for every Gateway present in
+// `previous` but absent from `current` — i.e. Gateways the route has detached from.
+// This removes the route's stale routing.json entries when parentRefs are edited,
+// the route is moved between Gateways, or its parentRefs are dropped to zero.
+// Deleted Gateways and Gateways not managed by our GatewayClass are skipped.
+func (r *HTTPRouteReconciler) regenerateDetachedGateways(ctx context.Context, previous, current map[types.NamespacedName]bool) error {
+	for nn := range previous {
+		if current[nn] {
+			continue
+		}
+		var gw gatewayv1.Gateway
+		if err := r.Get(ctx, nn, &gw); err != nil {
+			if apierrors.IsNotFound(err) {
+				continue // Gateway gone; its ConfigMap went with it
+			}
+			return fmt.Errorf("r.Get(%s): %w", nn, err)
+		}
+		if !isOurGatewayClass(ctx, r.Client, string(gw.Spec.GatewayClassName)) {
+			continue
+		}
+		routes, err := r.listRoutesForGateway(ctx, &gw)
+		if err != nil {
+			return fmt.Errorf("r.listRoutesForGateway(%s): %w", nn, err)
+		}
+		if err := r.updateConfigMap(ctx, &gw, routes); err != nil {
+			return fmt.Errorf("r.updateConfigMap(%s): %w", nn, err)
+		}
+		r.Logger.Info("regenerated routing.json for detached gateway", "gateway", nn.String())
+	}
+	return nil
 }
 
 // regenerateAllGateways lists all Gateways managed by our GatewayClass and

--- a/internal/controller/httproute_controller_test.go
+++ b/internal/controller/httproute_controller_test.go
@@ -1049,6 +1049,16 @@ func TestIsRouteAllowedByGateway(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			// Real routes always reference the Gateway via a parentRef; the
+			// per-listener attachment check operates over parentRefs. Synthesize a
+			// parentRef targeting the Gateway (in the Gateway's namespace, so
+			// cross-namespace routes still target it) when the case omits one.
+			if len(tc.route.Spec.ParentRefs) == 0 {
+				gwNS := gatewayv1.Namespace(tc.gateway.Namespace)
+				tc.route.Spec.ParentRefs = []gatewayv1.ParentReference{
+					{Name: gatewayv1.ObjectName(tc.gateway.Name), Namespace: &gwNS},
+				}
+			}
 			objs := append([]runtime.Object{}, tc.objs...)
 			r := newHTTPRouteTestReconciler(scheme, objs...)
 			got, _, _ := isRouteAllowedByGateway(context.Background(), r.Client, tc.route, tc.gateway)
@@ -1930,3 +1940,269 @@ func TestReconcile_ExternalNameBackend(t *testing.T) {
 }
 
 // NOTE: getUserVCL tests removed - functionality moved to Gateway controller
+
+// --- H-3: per-listener AllowedRoutes namespace policy ---
+
+// TestComputeListenerAttachment_PerListenerNamespace verifies that attachment is
+// computed per listener: a foreign-namespace route on a Gateway with a from:Same
+// and a from:All listener attaches ONLY to the from:All listener, never leaking
+// onto the from:Same listener (the H-3 bypass).
+func TestComputeListenerAttachment_PerListenerNamespace(t *testing.T) {
+	scheme := newTestScheme()
+	fromSame := gatewayv1.NamespacesFromSame
+	fromAll := gatewayv1.NamespacesFromAll
+
+	gateway := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "gw", Namespace: "default"},
+		Spec: gatewayv1.GatewaySpec{
+			Listeners: []gatewayv1.Listener{
+				{
+					Name: "http-same", Port: 80, Protocol: gatewayv1.HTTPProtocolType,
+					AllowedRoutes: &gatewayv1.AllowedRoutes{
+						Namespaces: &gatewayv1.RouteNamespaces{From: &fromSame},
+					},
+				},
+				{
+					Name: "http-all", Port: 8080, Protocol: gatewayv1.HTTPProtocolType,
+					AllowedRoutes: &gatewayv1.AllowedRoutes{
+						Namespaces: &gatewayv1.RouteNamespaces{From: &fromAll},
+					},
+				},
+			},
+		},
+	}
+
+	gwNS := gatewayv1.Namespace("default")
+
+	t.Run("foreign namespace attaches only to from:All listener", func(t *testing.T) {
+		route := &gatewayv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "other"},
+			Spec: gatewayv1.HTTPRouteSpec{CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{{Name: "gw", Namespace: &gwNS}},
+			}},
+		}
+		r := newHTTPRouteTestReconciler(scheme)
+		att := computeListenerAttachment(context.Background(), r.Client, route, gateway)
+		if len(att.listenerNames) != 1 || att.listenerNames[0] != "http-all" {
+			t.Fatalf("expected attachment [http-all], got %v", att.listenerNames)
+		}
+		if !att.namespaceAllowed {
+			t.Error("expected namespaceAllowed=true (from:All listener allowed the namespace)")
+		}
+	})
+
+	t.Run("same namespace attaches to both listeners", func(t *testing.T) {
+		route := &gatewayv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "default"},
+			Spec: gatewayv1.HTTPRouteSpec{CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{{Name: "gw"}},
+			}},
+		}
+		r := newHTTPRouteTestReconciler(scheme)
+		att := computeListenerAttachment(context.Background(), r.Client, route, gateway)
+		if len(att.listenerNames) != 2 {
+			t.Fatalf("expected attachment to both listeners, got %v", att.listenerNames)
+		}
+	})
+
+	t.Run("foreign namespace pinned to from:Same via sectionName is rejected", func(t *testing.T) {
+		sn := gatewayv1.SectionName("http-same")
+		route := &gatewayv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "other"},
+			Spec: gatewayv1.HTTPRouteSpec{CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{{Name: "gw", Namespace: &gwNS, SectionName: &sn}},
+			}},
+		}
+		r := newHTTPRouteTestReconciler(scheme)
+		att := computeListenerAttachment(context.Background(), r.Client, route, gateway)
+		if len(att.listenerNames) != 0 {
+			t.Fatalf("expected no attachment (from:Same denies foreign ns), got %v", att.listenerNames)
+		}
+		allowed, reason, _ := isRouteAllowedByGateway(context.Background(), r.Client, route, gateway)
+		if allowed {
+			t.Error("expected route not allowed")
+		}
+		if reason != string(gatewayv1.RouteReasonNotAllowedByListeners) {
+			t.Errorf("expected NotAllowedByListeners, got %s", reason)
+		}
+	})
+}
+
+// --- H-4: effectiveHostnames catch-all vs no-intersection ---
+
+func TestEffectiveHostnames_CatchAllSignal(t *testing.T) {
+	hn := func(s string) *gatewayv1.Hostname { h := gatewayv1.Hostname(s); return &h }
+
+	gateway := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "gw", Namespace: "default"},
+		Spec: gatewayv1.GatewaySpec{
+			Listeners: []gatewayv1.Listener{
+				{Name: "l-open", Port: 80, Protocol: gatewayv1.HTTPProtocolType}, // no hostname
+				{Name: "l-a", Port: 8080, Protocol: gatewayv1.HTTPProtocolType, Hostname: hn("a.com")},
+			},
+		},
+	}
+
+	t.Run("genuine catch-all", func(t *testing.T) {
+		route := &gatewayv1.HTTPRoute{ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "default"}}
+		snOpen := gatewayv1.SectionName("l-open")
+		got, catchAll := effectiveHostnames(route, gateway, &snOpen, nil, nil)
+		if !catchAll {
+			t.Fatalf("expected catchAll=true, got hostnames=%v", got)
+		}
+	})
+
+	t.Run("no intersection is not catch-all", func(t *testing.T) {
+		route := &gatewayv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "default"},
+			Spec:       gatewayv1.HTTPRouteSpec{Hostnames: []gatewayv1.Hostname{"b.com"}},
+		}
+		snA := gatewayv1.SectionName("l-a")
+		got, catchAll := effectiveHostnames(route, gateway, &snA, nil, nil)
+		if catchAll {
+			t.Fatal("expected catchAll=false for no-intersection")
+		}
+		if len(got) != 0 {
+			t.Errorf("expected no effective hostnames, got %v", got)
+		}
+	})
+
+	t.Run("sectionName matching no listener is not catch-all", func(t *testing.T) {
+		route := &gatewayv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "default"},
+			Spec:       gatewayv1.HTTPRouteSpec{Hostnames: []gatewayv1.Hostname{"a.com"}},
+		}
+		snMissing := gatewayv1.SectionName("does-not-exist")
+		got, catchAll := effectiveHostnames(route, gateway, &snMissing, nil, nil)
+		if catchAll {
+			t.Fatal("expected catchAll=false when sectionName matches no listener")
+		}
+		if len(got) != 0 {
+			t.Errorf("expected no effective hostnames, got %v", got)
+		}
+	})
+
+	t.Run("intersection yields effective hostname", func(t *testing.T) {
+		route := &gatewayv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "default"},
+			Spec:       gatewayv1.HTTPRouteSpec{Hostnames: []gatewayv1.Hostname{"a.com"}},
+		}
+		snA := gatewayv1.SectionName("l-a")
+		got, catchAll := effectiveHostnames(route, gateway, &snA, nil, nil)
+		if catchAll {
+			t.Fatal("expected catchAll=false")
+		}
+		if len(got) != 1 || got[0] != "a.com" {
+			t.Errorf("expected [a.com], got %v", got)
+		}
+	})
+}
+
+// TestFilterRouteHostnames_MultiParentRefNoBreak verifies that a parentRef with no
+// hostname intersection contributes nothing but does NOT discard hostnames from
+// other parentRefs, and is not misinterpreted as a full catch-all (H-4).
+func TestFilterRouteHostnames_MultiParentRefNoBreak(t *testing.T) {
+	scheme := newTestScheme()
+	hn := func(s string) *gatewayv1.Hostname { h := gatewayv1.Hostname(s); return &h }
+
+	gateway := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "gw", Namespace: "default"},
+		Spec: gatewayv1.GatewaySpec{
+			Listeners: []gatewayv1.Listener{
+				{Name: "la", Port: 80, Protocol: gatewayv1.HTTPProtocolType, Hostname: hn("a.com")},
+				{Name: "lc", Port: 8080, Protocol: gatewayv1.HTTPProtocolType, Hostname: hn("c.com")},
+			},
+		},
+	}
+
+	snLc := gatewayv1.SectionName("lc")
+	snLa := gatewayv1.SectionName("la")
+	route := gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "default"},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{
+					// First parentRef targets lc (c.com) — no intersection with the
+					// route's hostnames. The buggy code broke here and promoted the
+					// route to catch-all, keeping the full hostname set.
+					{Name: "gw", SectionName: &snLc},
+					{Name: "gw", SectionName: &snLa},
+				},
+			},
+			Hostnames: []gatewayv1.Hostname{"a.com", "b.com"},
+		},
+	}
+
+	r := newHTTPRouteTestReconciler(scheme)
+	att := computeListenerAttachment(context.Background(), r.Client, &route, gateway)
+	attachments := map[string]listenerAttachment{"default/r": att}
+
+	filtered := filterRouteHostnames([]gatewayv1.HTTPRoute{route}, gateway, attachments)
+	if len(filtered) != 1 {
+		t.Fatalf("expected 1 filtered route, got %d", len(filtered))
+	}
+	got := filtered[0].Spec.Hostnames
+	if len(got) != 1 || got[0] != "a.com" {
+		t.Errorf("expected hostnames [a.com] (b.com dropped, not promoted to catch-all), got %v", got)
+	}
+}
+
+// --- H-5: stale-route cleanup helpers ---
+
+func TestGatewaysFromRouteSpecAndStatus(t *testing.T) {
+	nsB := gatewayv1.Namespace("gw-ns")
+	route := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "default"},
+		Spec: gatewayv1.HTTPRouteSpec{CommonRouteSpec: gatewayv1.CommonRouteSpec{
+			ParentRefs: []gatewayv1.ParentReference{
+				{Name: "gw-a"},                  // default ns
+				{Name: "gw-b", Namespace: &nsB}, // explicit ns
+			},
+		}},
+		Status: gatewayv1.HTTPRouteStatus{RouteStatus: gatewayv1.RouteStatus{
+			Parents: []gatewayv1.RouteParentStatus{
+				{ControllerName: ControllerName, ParentRef: gatewayv1.ParentReference{Name: "gw-a"}},
+				{ControllerName: "someone-else/controller", ParentRef: gatewayv1.ParentReference{Name: "gw-x"}},
+			},
+		}},
+	}
+
+	spec := gatewaysFromRouteSpec(route)
+	if !spec[types.NamespacedName{Name: "gw-a", Namespace: "default"}] ||
+		!spec[types.NamespacedName{Name: "gw-b", Namespace: "gw-ns"}] {
+		t.Errorf("gatewaysFromRouteSpec missing expected gateways: %v", spec)
+	}
+
+	status := gatewaysFromRouteStatus(route)
+	if !status[types.NamespacedName{Name: "gw-a", Namespace: "default"}] {
+		t.Errorf("gatewaysFromRouteStatus should include our gw-a: %v", status)
+	}
+	if status[types.NamespacedName{Name: "gw-x", Namespace: "default"}] {
+		t.Errorf("gatewaysFromRouteStatus should exclude other controller's gw-x: %v", status)
+	}
+}
+
+func TestPruneDetachedRouteParents(t *testing.T) {
+	route := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "default"},
+		Status: gatewayv1.HTTPRouteStatus{RouteStatus: gatewayv1.RouteStatus{
+			Parents: []gatewayv1.RouteParentStatus{
+				{ControllerName: ControllerName, ParentRef: gatewayv1.ParentReference{Name: "gw-a"}},            // detached
+				{ControllerName: ControllerName, ParentRef: gatewayv1.ParentReference{Name: "gw-b"}},            // current
+				{ControllerName: "someone-else/controller", ParentRef: gatewayv1.ParentReference{Name: "gw-a"}}, // foreign, keep
+			},
+		}},
+	}
+	current := map[types.NamespacedName]bool{{Name: "gw-b", Namespace: "default"}: true}
+
+	pruneDetachedRouteParents(route, current)
+
+	if len(route.Status.Parents) != 2 {
+		t.Fatalf("expected 2 parents after prune, got %d: %+v", len(route.Status.Parents), route.Status.Parents)
+	}
+	for _, ps := range route.Status.Parents {
+		if string(ps.ControllerName) == ControllerName && ps.ParentRef.Name == "gw-a" {
+			t.Error("stale our-controller gw-a entry should have been pruned")
+		}
+	}
+}

--- a/internal/controller/resources.go
+++ b/internal/controller/resources.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"sort"
@@ -126,6 +127,21 @@ func (r *GatewayReconciler) buildAdminSecret(gateway *gatewayv1.Gateway) *corev1
 			"secret": []byte(secretHex),
 		},
 	}
+}
+
+// drainToken derives a stable, non-guessable token that guards the /drain
+// endpoint against a cross-pod one-request DoS.
+//
+// It is derived deterministically from the Gateway UID (assigned by the API
+// server at creation, stable for the object's lifetime) rather than freshly
+// randomized: a value that changed on every reconcile would rewrite the pod
+// template each time and trigger endless rolling restarts, and the env var
+// must stay in lockstep with the preStop hook header. The token never appears
+// on the HTTP data path — learning it requires read access to the Gateway
+// object (RBAC-gated), which a peer pod firing a raw packet does not have.
+func drainToken(gateway *gatewayv1.Gateway) string {
+	sum := sha256.Sum256([]byte("varnish-gateway-drain\x00" + string(gateway.UID)))
+	return hex.EncodeToString(sum[:])
 }
 
 // buildTLSSecret creates a Secret containing the combined PEM files for TLS termination.
@@ -425,7 +441,14 @@ func (r *GatewayReconciler) buildGatewayContainer(gateway *gatewayv1.Gateway, cf
 		{Name: "WORK_DIR", Value: "/var/run/varnish"},
 		{Name: "VARNISH_DIR", Value: "/var/run/varnish/vsm"}, // VSM subdirectory on shared volume
 		{Name: "HEALTH_ADDR", Value: fmt.Sprintf(":%d", chaperoneHealthPort)},
-		{Name: "DASHBOARD_ADDR", Value: fmt.Sprintf(":%d", chaperoneDashboardPort)},
+		// Dashboard binds to loopback only. It is reached via `kubectl
+		// port-forward`, which forwards into the pod network namespace and can
+		// reach 127.0.0.1 — so binding loopback keeps port-forward working
+		// while removing the dashboard from the cluster-internal attack surface.
+		{Name: "DASHBOARD_ADDR", Value: fmt.Sprintf("127.0.0.1:%d", chaperoneDashboardPort)},
+		// DRAIN_TOKEN guards the /drain endpoint (see drainToken). The same
+		// value is sent by the preStop hook below via the X-Drain-Token header.
+		{Name: "DRAIN_TOKEN", Value: drainToken(gateway)},
 		{Name: "GATEWAY_NAME", Value: gateway.Name},
 		{
 			Name: "POD_NAME",
@@ -539,13 +562,21 @@ func (r *GatewayReconciler) buildGatewayContainer(gateway *gatewayv1.Gateway, cf
 		Ports:        ports,
 		VolumeMounts: volumeMounts,
 		Resources:    resourceReqs,
-		// PreStop hook triggers graceful shutdown before SIGTERM
+		// PreStop hook triggers graceful shutdown before SIGTERM.
+		// The kubelet runs this HTTPGet against the pod IP, so /drain must stay
+		// reachable on the pod interface — it cannot move to loopback. To stop
+		// any peer pod from draining the gateway with a single unauthenticated
+		// request, /drain requires the shared-secret X-Drain-Token header,
+		// which only this pod's spec carries.
 		Lifecycle: &corev1.Lifecycle{
 			PreStop: &corev1.LifecycleHandler{
 				HTTPGet: &corev1.HTTPGetAction{
 					Path:   "/drain",
 					Port:   intstr.FromInt(chaperoneHealthPort),
 					Scheme: corev1.URISchemeHTTP,
+					HTTPHeaders: []corev1.HTTPHeader{
+						{Name: "X-Drain-Token", Value: drainToken(gateway)},
+					},
 				},
 			},
 		},

--- a/internal/controller/resources_test.go
+++ b/internal/controller/resources_test.go
@@ -888,6 +888,79 @@ func TestBuildGatewayContainer_VolumeMounts_BackendTLS(t *testing.T) {
 	}
 }
 
+// TestBuildGatewayContainer_DashboardLoopback verifies the dashboard binds to
+// loopback (H-2) so it is not exposed on the pod interface.
+func TestBuildGatewayContainer_DashboardLoopback(t *testing.T) {
+	r := testReconcilerSimple()
+	gw := testGateway("my-gw", "default")
+
+	container := r.buildGatewayContainer(gw, deploymentConfig{effectiveImage: "test:latest"})
+
+	var dashAddr string
+	for _, e := range container.Env {
+		if e.Name == "DASHBOARD_ADDR" {
+			dashAddr = e.Value
+		}
+	}
+	want := "127.0.0.1:9000"
+	if dashAddr != want {
+		t.Errorf("DASHBOARD_ADDR = %q, want %q (must bind loopback only)", dashAddr, want)
+	}
+}
+
+// TestBuildGatewayContainer_DrainTokenWired verifies the /drain shared secret
+// is injected via env and matched by the preStop hook header (H-2).
+func TestBuildGatewayContainer_DrainTokenWired(t *testing.T) {
+	r := testReconcilerSimple()
+	gw := testGateway("my-gw", "default")
+	gw.UID = "11111111-2222-3333-4444-555555555555"
+
+	container := r.buildGatewayContainer(gw, deploymentConfig{effectiveImage: "test:latest"})
+
+	var envToken string
+	for _, e := range container.Env {
+		if e.Name == "DRAIN_TOKEN" {
+			envToken = e.Value
+		}
+	}
+	if envToken == "" {
+		t.Fatal("DRAIN_TOKEN env var not set")
+	}
+	if envToken != drainToken(gw) {
+		t.Errorf("DRAIN_TOKEN env = %q, want %q", envToken, drainToken(gw))
+	}
+
+	if container.Lifecycle == nil || container.Lifecycle.PreStop == nil || container.Lifecycle.PreStop.HTTPGet == nil {
+		t.Fatal("expected preStop HTTPGet hook")
+	}
+	var hdrToken string
+	for _, h := range container.Lifecycle.PreStop.HTTPGet.HTTPHeaders {
+		if h.Name == "X-Drain-Token" {
+			hdrToken = h.Value
+		}
+	}
+	if hdrToken != envToken {
+		t.Errorf("preStop X-Drain-Token = %q, want it to match DRAIN_TOKEN env %q", hdrToken, envToken)
+	}
+}
+
+// TestDrainToken_StableAndDistinct verifies the token is deterministic for a
+// given Gateway UID (so it does not churn the pod template across reconciles)
+// and differs across UIDs.
+func TestDrainToken_StableAndDistinct(t *testing.T) {
+	a := testGateway("gw-a", "default")
+	a.UID = "aaaa"
+	b := testGateway("gw-b", "default")
+	b.UID = "bbbb"
+
+	if drainToken(a) != drainToken(a) {
+		t.Error("drainToken not deterministic for the same UID")
+	}
+	if drainToken(a) == drainToken(b) {
+		t.Error("drainToken collided across distinct UIDs")
+	}
+}
+
 // --- buildLoggingSidecar ---
 
 func TestBuildLoggingSidecar_Varnishlog(t *testing.T) {

--- a/internal/dashboard/events.go
+++ b/internal/dashboard/events.go
@@ -93,11 +93,18 @@ func (b *EventBus) Subscribe() chan Event {
 }
 
 // Unsubscribe removes a subscriber channel.
+//
+// The channel is deliberately NOT closed here. Publish snapshots the
+// subscriber set under the lock, releases it, then does non-blocking sends;
+// a send racing a close panics ("send on closed channel"), and select/default
+// does not guard against that. Receivers already terminate via ctx.Done()
+// (see server.handleSSE and runMetricsUpdater), so the channel simply becomes
+// unreferenced after Unsubscribe and is garbage-collected. Do not reintroduce
+// close(ch).
 func (b *EventBus) Unsubscribe(ch chan Event) {
 	b.mu.Lock()
 	delete(b.subscribers, ch)
 	b.mu.Unlock()
-	close(ch)
 }
 
 // Recent returns all events in the ring buffer, oldest first.

--- a/internal/dashboard/events_test.go
+++ b/internal/dashboard/events_test.go
@@ -1,6 +1,7 @@
 package dashboard
 
 import (
+	"sync"
 	"testing"
 	"time"
 )
@@ -127,16 +128,52 @@ func TestEventBus_Subscribe_ReceivesEvents(t *testing.T) {
 	bus.Unsubscribe(ch)
 }
 
-func TestEventBus_Unsubscribe_ClosesChannel(t *testing.T) {
+// TestEventBus_Unsubscribe_DoesNotCloseChannel guards the H-10 fix: Unsubscribe
+// must NOT close the subscriber channel. Publish does non-blocking sends after
+// releasing the lock, and a send racing a close panics ("send on closed
+// channel") — select/default does not guard against that. Receivers terminate
+// via ctx.Done() instead, so the channel is simply left for GC.
+func TestEventBus_Unsubscribe_DoesNotCloseChannel(t *testing.T) {
 	bus := NewEventBus(10)
 	ch := bus.Subscribe()
 	bus.Unsubscribe(ch)
 
-	// Channel should be closed
-	_, ok := <-ch
-	if ok {
-		t.Fatal("expected channel to be closed after unsubscribe")
+	// Channel must remain open (not closed). A receive should block rather
+	// than return the closed-channel zero value, so use a short timeout.
+	select {
+	case _, ok := <-ch:
+		if !ok {
+			t.Fatal("channel was closed by Unsubscribe; this reintroduces the send-on-closed-channel panic (H-10)")
+		}
+		t.Fatal("unexpected event delivered after unsubscribe")
+	case <-time.After(50 * time.Millisecond):
+		// Expected: open, empty channel blocks.
 	}
+}
+
+// TestEventBus_ConcurrentPublishUnsubscribe is a regression test for H-10: a
+// Publish racing an Unsubscribe must never panic. It fails (panics) if
+// Unsubscribe closes the channel while Publish is sending.
+func TestEventBus_ConcurrentPublishUnsubscribe(t *testing.T) {
+	bus := NewEventBus(10)
+	var wg sync.WaitGroup
+
+	for i := 0; i < 50; i++ {
+		ch := bus.Subscribe()
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				bus.Publish(Event{Type: EventReady, Message: "race"})
+			}
+		}()
+		go func(c chan Event) {
+			defer wg.Done()
+			bus.Unsubscribe(c)
+		}(ch)
+	}
+
+	wg.Wait()
 }
 
 func TestEventBus_Unsubscribe_StopsDelivery(t *testing.T) {

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -50,6 +50,13 @@ func (s *Server) Run(ctx context.Context) error {
 	srv := &http.Server{
 		Addr:    s.addr,
 		Handler: mux,
+		// The dashboard serves long-lived SSE streams (/api/events,
+		// /api/varnishlog), so WriteTimeout must stay 0 (unbounded) — a finite
+		// value would kill active streams mid-flight. ReadHeaderTimeout guards
+		// against Slowloris-style header stalls, and IdleTimeout reaps idle
+		// keep-alive connections.
+		ReadHeaderTimeout: 10 * time.Second,
+		IdleTimeout:       120 * time.Second,
 	}
 
 	go func() {
@@ -94,7 +101,6 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
-	w.Header().Set("Access-Control-Allow-Origin", "*")
 	flusher.Flush()
 
 	ch := s.bus.Subscribe()

--- a/internal/dashboard/varnishlog.go
+++ b/internal/dashboard/varnishlog.go
@@ -235,7 +235,6 @@ func (s *Server) handleVarnishlog(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
-	w.Header().Set("Access-Control-Allow-Origin", "*")
 	flusher.Flush()
 
 	scanner := bufio.NewScanner(stdout)

--- a/internal/tls/reloader.go
+++ b/internal/tls/reloader.go
@@ -233,6 +233,27 @@ func (r *Reloader) reloadAllCerts() error {
 	return nil
 }
 
+// shouldReload reports whether an fsnotify event should trigger a certificate
+// reload. Two kinds of change are relevant:
+//
+//  1. Direct .pem writes — used by non-Kubernetes deployments and tests.
+//  2. Kubernetes Secret volume rotation. K8s populates mounted Secret volumes
+//     with the atomic-writer pattern: it writes cert data into a new
+//     "..<timestamp>" directory and atomically swaps the "..data" symlink to
+//     point at it (surfacing as a Create/Rename on "..data"). The visible
+//     foo.pem entries are symlinks created only at initial volume setup and
+//     never touched again, so no .pem event ever fires on renewal. Watching
+//     "..data" is what makes cert-manager renewals / Secret updates actually
+//     trigger a reload instead of serving the stale cert until pod restart.
+func shouldReload(event fsnotify.Event) bool {
+	// Only act on ops that can change cert contents on disk.
+	if !event.Has(fsnotify.Write) && !event.Has(fsnotify.Create) && !event.Has(fsnotify.Remove) && !event.Has(fsnotify.Rename) {
+		return false
+	}
+	// event.Name is a full path; the atomic-writer symlink is the base "..data".
+	return filepath.Base(event.Name) == "..data" || strings.HasSuffix(event.Name, ".pem")
+}
+
 // Run starts watching the cert directory for changes and reloads certs when files change.
 // It blocks until the context is cancelled.
 func (r *Reloader) Run(ctx context.Context) error {
@@ -256,12 +277,7 @@ func (r *Reloader) Run(ctx context.Context) error {
 				return nil
 			}
 
-			// React to write, create, and remove events on .pem files
-			if !event.Has(fsnotify.Write) && !event.Has(fsnotify.Create) && !event.Has(fsnotify.Remove) && !event.Has(fsnotify.Rename) {
-				continue
-			}
-
-			if !strings.HasSuffix(event.Name, ".pem") {
+			if !shouldReload(event) {
 				continue
 			}
 

--- a/internal/tls/reloader_test.go
+++ b/internal/tls/reloader_test.go
@@ -5,12 +5,86 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/varnish/gateway/internal/varnishadm"
 )
+
+// TestShouldReload is the deterministic, platform-independent guard for the
+// H-9 fix: fsnotify events on the Kubernetes atomic-writer "..data" symlink
+// must trigger a reload (previously only .pem events did, so Secret rotations
+// were silently missed). It also confirms direct .pem writes still reload.
+func TestShouldReload(t *testing.T) {
+	const base = "/etc/varnish/tls"
+	tests := []struct {
+		name  string
+		event fsnotify.Event
+		want  bool
+	}{
+		{
+			name:  "k8s atomic-writer swap (rename-over surfaces as Create on ..data)",
+			event: fsnotify.Event{Name: base + "/..data", Op: fsnotify.Create},
+			want:  true,
+		},
+		{
+			name:  "k8s ..data swap seen as Rename",
+			event: fsnotify.Event{Name: base + "/..data", Op: fsnotify.Rename},
+			want:  true,
+		},
+		{
+			name:  "direct .pem write still reloads",
+			event: fsnotify.Event{Name: base + "/my-cert.pem", Op: fsnotify.Write},
+			want:  true,
+		},
+		{
+			name:  "new .pem created still reloads",
+			event: fsnotify.Event{Name: base + "/new-cert.pem", Op: fsnotify.Create},
+			want:  true,
+		},
+		{
+			name:  ".pem removed still reloads",
+			event: fsnotify.Event{Name: base + "/gone.pem", Op: fsnotify.Remove},
+			want:  true,
+		},
+		{
+			name:  "atomic-writer temp symlink does not reload",
+			event: fsnotify.Event{Name: base + "/..data_tmp", Op: fsnotify.Create},
+			want:  false,
+		},
+		{
+			name:  "timestamped data dir does not reload on its own",
+			event: fsnotify.Event{Name: base + "/..2026_07_23_10_00_00.111111", Op: fsnotify.Create},
+			want:  false,
+		},
+		{
+			name:  "unrelated file does not reload",
+			event: fsnotify.Event{Name: base + "/notes.txt", Op: fsnotify.Write},
+			want:  false,
+		},
+		{
+			name:  "chmod-only on .pem does not reload",
+			event: fsnotify.Event{Name: base + "/my-cert.pem", Op: fsnotify.Chmod},
+			want:  false,
+		},
+		{
+			name:  "chmod-only on ..data does not reload",
+			event: fsnotify.Event{Name: base + "/..data", Op: fsnotify.Chmod},
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldReload(tt.event); got != tt.want {
+				t.Errorf("shouldReload(%q, %s) = %v, want %v", tt.event.Name, tt.event.Op, got, tt.want)
+			}
+		})
+	}
+}
 
 func TestLoadAll_NoPEMFiles(t *testing.T) {
 	dir := t.TempDir()
@@ -359,6 +433,160 @@ func TestRun_CertRemovedTriggersReload(t *testing.T) {
 	state := mock.GetTLSState()
 	if len(state) != 1 {
 		t.Errorf("Expected 1 committed cert after removal, got %d", len(state))
+	}
+
+	cancel()
+}
+
+// writeK8sSecretVolume lays out a directory the way Kubernetes' atomic-writer
+// populates a mounted Secret volume: cert data lives in a timestamped
+// "..<timestamp>" directory, "..data" is a symlink to it, and each visible
+// entry (tls.crt, tls.key, *.pem) is a symlink into "..data".
+// It returns the name of the timestamped data directory it created.
+func writeK8sSecretVolume(t *testing.T, dir, timestampDir string, files map[string][]byte) string {
+	t.Helper()
+
+	dataDir := filepath.Join(dir, timestampDir)
+	if err := os.Mkdir(dataDir, 0755); err != nil {
+		t.Fatalf("os.Mkdir(%s): %v", dataDir, err)
+	}
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(dataDir, name), content, 0644); err != nil {
+			t.Fatalf("os.WriteFile(%s): %v", name, err)
+		}
+	}
+
+	// ..data -> ..<timestamp>
+	dataLink := filepath.Join(dir, "..data")
+	if err := os.Symlink(timestampDir, dataLink); err != nil {
+		t.Fatalf("os.Symlink(..data): %v", err)
+	}
+
+	// Visible entries are symlinks into ..data.
+	for name := range files {
+		visible := filepath.Join(dir, name)
+		if err := os.Symlink(filepath.Join("..data", name), visible); err != nil {
+			t.Fatalf("os.Symlink(%s): %v", name, err)
+		}
+	}
+
+	return timestampDir
+}
+
+// rotateK8sSecretVolume simulates cert-manager renewing the Secret: the
+// atomic-writer writes a fresh "..<timestamp>" directory and atomically swaps
+// the "..data" symlink to point at it (symlink to a temp name + rename over
+// "..data"). Crucially, the visible *.pem symlinks are NOT recreated — matching
+// real Kubernetes behavior — so only "..data" changes on disk.
+func rotateK8sSecretVolume(t *testing.T, dir, newTimestampDir string, files map[string][]byte) {
+	t.Helper()
+
+	newDataDir := filepath.Join(dir, newTimestampDir)
+	if err := os.Mkdir(newDataDir, 0755); err != nil {
+		t.Fatalf("os.Mkdir(%s): %v", newDataDir, err)
+	}
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(newDataDir, name), content, 0644); err != nil {
+			t.Fatalf("os.WriteFile(%s): %v", name, err)
+		}
+	}
+
+	// Atomic swap: create a temporary symlink, then rename it over ..data.
+	tmpLink := filepath.Join(dir, "..data_tmp")
+	if err := os.Symlink(newTimestampDir, tmpLink); err != nil {
+		t.Fatalf("os.Symlink(..data_tmp): %v", err)
+	}
+	if err := os.Rename(tmpLink, filepath.Join(dir, "..data")); err != nil {
+		t.Fatalf("os.Rename(..data): %v", err)
+	}
+}
+
+// TestRun_K8sSecretRotationTriggersReload verifies the reloader reacts to a
+// Kubernetes Secret volume rotation. Real Secret volumes never fire a *.pem
+// fsnotify event on renewal (the visible .pem entries are stable symlinks);
+// only the "..data" symlink is swapped. The reloader must watch "..data" or it
+// serves the stale cert until pod restart.
+func TestRun_K8sSecretRotationTriggersReload(t *testing.T) {
+	// This is an OS-level integration test of the fsnotify watch path. On
+	// Linux (inotify) the atomic-writer's rename-over-"..data" surfaces as an
+	// IN_MOVED_TO -> Create event named ".../..data", which the filter catches.
+	// macOS (kqueue) detects directory changes by name-diffing and cannot
+	// observe an in-place symlink swap (the "..data" name is unchanged across
+	// the rename), so the event never fires there regardless of the filter.
+	// The deterministic guard for the fix is TestShouldReload; this test
+	// exercises the real watcher on the platform that behaves like production.
+	if runtime.GOOS != "linux" {
+		t.Skipf("kqueue on %s cannot observe an in-place '..data' symlink swap; see TestShouldReload", runtime.GOOS)
+	}
+
+	dir := t.TempDir()
+
+	certFiles := map[string][]byte{
+		"tls.crt":     []byte("-----BEGIN CERTIFICATE-----\ninitial\n-----END CERTIFICATE-----\n"),
+		"tls.key":     []byte("-----BEGIN PRIVATE KEY-----\ninitial\n-----END PRIVATE KEY-----\n"),
+		"my-cert.pem": []byte("initial cert+key PEM"),
+	}
+	writeK8sSecretVolume(t, dir, "..2026_07_23_10_00_00.111111", certFiles)
+
+	mock := varnishadm.NewMock(0, "", slog.Default())
+	// The my-cert.pem symlink is already loaded (as if via LoadAll at startup).
+	mock.SetTLSState([]varnishadm.TLSCertEntry{
+		{CertificateID: "my-cert", Frontend: "main", State: "active", Hostname: "my-cert"},
+	})
+
+	r := New(mock, dir, slog.Default())
+	r.debounceDelay = 50 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- r.Run(ctx)
+	}()
+
+	// Give the watcher time to start.
+	time.Sleep(100 * time.Millisecond)
+
+	// Rotate: only "..data" changes on disk, no .pem event fires.
+	mock.ClearCallHistory()
+	rotateK8sSecretVolume(t, dir, "..2026_07_23_11_00_00.222222", map[string][]byte{
+		"tls.crt":     []byte("-----BEGIN CERTIFICATE-----\nrenewed\n-----END CERTIFICATE-----\n"),
+		"tls.key":     []byte("-----BEGIN PRIVATE KEY-----\nrenewed\n-----END PRIVATE KEY-----\n"),
+		"my-cert.pem": []byte("renewed cert+key PEM"),
+	})
+
+	// Wait for debounce + processing.
+	time.Sleep(300 * time.Millisecond)
+
+	// The rotation must have triggered a full reload cycle.
+	history := mock.GetCallHistory()
+	var foundList, foundDiscard, foundLoad, foundCommit bool
+	for _, cmd := range history {
+		if cmd == "tls.cert.list" {
+			foundList = true
+		}
+		if cmd == "tls.cert.discard my-cert" {
+			foundDiscard = true
+		}
+		if strings.HasPrefix(cmd, "tls.cert.load my-cert ") {
+			foundLoad = true
+		}
+		if cmd == "tls.cert.commit" {
+			foundCommit = true
+		}
+	}
+	if !foundList {
+		t.Errorf("Run() did not call tls.cert.list after Secret rotation; history: %v", history)
+	}
+	if !foundDiscard {
+		t.Errorf("Run() did not discard existing cert after Secret rotation; history: %v", history)
+	}
+	if !foundLoad {
+		t.Errorf("Run() did not reload cert after Secret rotation; history: %v", history)
+	}
+	if !foundCommit {
+		t.Errorf("Run() did not commit after Secret rotation; history: %v", history)
 	}
 
 	cancel()

--- a/internal/varnishadm/commands.go
+++ b/internal/varnishadm/commands.go
@@ -1,8 +1,11 @@
 package varnishadm
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -46,10 +49,51 @@ func (v *Server) VCLLoad(name, path string) (VarnishResponse, error) {
 	return v.Exec(cmd)
 }
 
-// VCLInline loads VCL configuration inline (without a file)
+// VCLInline loads VCL configuration inline (without a file).
+//
+// The VCL is delivered via a Varnish CLI heredoc. Using a fixed delimiter
+// (e.g. "EOF") is unsafe: user VCL is merged verbatim, so a line in the VCL
+// that is exactly the delimiter would close the heredoc early and let the
+// following lines execute as CLI commands (stop, param.set cc_command, ...).
+// We generate an unguessable per-call delimiter from crypto/rand so no
+// attacker-supplied VCL can predict and inject it, and additionally reject
+// (rather than silently mis-parse) the astronomically unlikely case where the
+// VCL still contains a line equal to the chosen delimiter.
 func (v *Server) VCLInline(name, vcl string) (VarnishResponse, error) {
-	cmd := fmt.Sprintf("vcl.inline %s << EOF\n%s\nEOF", name, vcl)
+	delimiter, err := heredocDelimiter()
+	if err != nil {
+		return VarnishResponse{}, fmt.Errorf("heredocDelimiter(): %w", err)
+	}
+	// Belt-and-suspenders: guarantee the delimiter cannot appear as a standalone
+	// line in the payload. With 128 bits of randomness this should never fire.
+	if containsLine(vcl, delimiter) {
+		return VarnishResponse{}, fmt.Errorf("VCLInline: generated heredoc delimiter %q collides with a line in the VCL payload", delimiter)
+	}
+	cmd := fmt.Sprintf("vcl.inline %s << %s\n%s\n%s", name, delimiter, vcl, delimiter)
 	return v.Exec(cmd)
+}
+
+// heredocDelimiter returns an unguessable heredoc delimiter word of the form
+// "EOF_<32 hex chars>" backed by 128 bits of cryptographic randomness. The
+// Varnish CLI accepts any single word as the heredoc terminator.
+func heredocDelimiter() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", fmt.Errorf("rand.Read: %w", err)
+	}
+	return "EOF_" + hex.EncodeToString(b[:]), nil
+}
+
+// containsLine reports whether s contains a line exactly equal to line.
+// Both "\n" and "\r\n" line endings are considered so a trailing CR cannot
+// smuggle a delimiter past the check.
+func containsLine(s, line string) bool {
+	for _, l := range strings.Split(s, "\n") {
+		if strings.TrimRight(l, "\r") == line {
+			return true
+		}
+	}
+	return false
 }
 
 // VCLUse switches to using the specified VCL configuration

--- a/internal/varnishadm/commands_test.go
+++ b/internal/varnishadm/commands_test.go
@@ -668,3 +668,53 @@ func TestCommands_BackendCommands(t *testing.T) {
 		}
 	})
 }
+
+// TestHeredocDelimiter verifies the per-call heredoc delimiter is unguessable
+// and unique (H-8 regression). Each call must produce a distinct, well-formed
+// "EOF_<hex>" word so attacker-supplied VCL cannot predict and inject it.
+func TestHeredocDelimiter(t *testing.T) {
+	seen := make(map[string]struct{})
+	for i := 0; i < 1000; i++ {
+		d, err := heredocDelimiter()
+		if err != nil {
+			t.Fatalf("heredocDelimiter() error: %v", err)
+		}
+		if !strings.HasPrefix(d, "EOF_") {
+			t.Fatalf("delimiter %q missing EOF_ prefix", d)
+		}
+		hexPart := strings.TrimPrefix(d, "EOF_")
+		if len(hexPart) != 32 {
+			t.Fatalf("delimiter %q hex part = %d chars, want 32", d, len(hexPart))
+		}
+		if _, dup := seen[d]; dup {
+			t.Fatalf("duplicate delimiter generated: %q", d)
+		}
+		seen[d] = struct{}{}
+	}
+}
+
+// TestContainsLine covers the belt-and-suspenders guard that stops a VCL
+// payload from smuggling a line equal to the heredoc delimiter (H-8).
+func TestContainsLine(t *testing.T) {
+	tests := []struct {
+		name string
+		s    string
+		line string
+		want bool
+	}{
+		{"empty payload", "", "EOF", false},
+		{"exact single line", "EOF", "EOF", true},
+		{"line in middle", "a\nEOF\nb", "EOF", true},
+		{"substring not a full line", "xEOFy", "EOF", false},
+		{"trailing CR still matches", "a\nEOF\r\nb", "EOF", true},
+		{"not present", "vcl 4.0;\nbackend b {}", "EOF_deadbeef", false},
+		{"delimiter as last line no newline", "a\nb\nEOF", "EOF", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := containsLine(tt.s, tt.line); got != tt.want {
+				t.Errorf("containsLine(%q, %q) = %v, want %v", tt.s, tt.line, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/varnishadm/protocol_test.go
+++ b/internal/varnishadm/protocol_test.go
@@ -267,6 +267,35 @@ func TestReadFromConnection(t *testing.T) {
 		}
 	})
 
+	t.Run("negative body length", func(t *testing.T) {
+		// A malformed/malicious peer sending a negative length must be rejected
+		// with an error, never reach make([]byte, bodyLen+1) (which panics for
+		// bodyLen <= -2) or index bodyWithNewline[bodyLen] at -1. Regression
+		// test for H-7.
+		negLengths := []int{-1, -2, -100}
+		for _, nl := range negLengths {
+			t.Run(fmt.Sprintf("len_%d", nl), func(t *testing.T) {
+				serverSide, varnishdSide := makeTCPPair(t)
+				defer serverSide.Close()
+				defer varnishdSide.Close()
+
+				go func() {
+					// 8-char right-justified length field, e.g. "      -1".
+					header := fmt.Sprintf("200 %8d\n", nl)
+					_, _ = varnishdSide.Write([]byte(header))
+				}()
+
+				_, _, err := s.readFromConnection(serverSide, 5*time.Second)
+				if err == nil {
+					t.Fatalf("expected error for negative body length %d", nl)
+				}
+				if !strings.Contains(err.Error(), "negative body length") {
+					t.Errorf("error = %q, want 'negative body length' message", err.Error())
+				}
+			})
+		}
+	})
+
 	t.Run("body length exceeds maximum", func(t *testing.T) {
 		serverSide, varnishdSide := makeTCPPair(t)
 		defer serverSide.Close()

--- a/internal/varnishadm/varnishadm.go
+++ b/internal/varnishadm/varnishadm.go
@@ -150,10 +150,17 @@ func (v *Server) Run(ctx context.Context) error {
 	// Signal shutdown to any pending Exec callers on return.
 	defer v.doneOnce.Do(func() { close(v.done) })
 
-	v.logger.Debug("Starting varnishadm server on localhost", "port", v.Port)
-	l, err := net.Listen("tcp", fmt.Sprintf(":%d", v.Port))
+	// Bind IPv4 loopback only. varnishd runs in the same pod and dials
+	// -M 127.0.0.1:<port> (see vrun.BuildArgs). Both sides must agree on the
+	// same loopback address; binding 127.0.0.1 (rather than ":" = all
+	// interfaces) keeps the reverse-mode admin channel unreachable from
+	// outside the pod. Using the literal 127.0.0.1 on both sides avoids the
+	// IPv4/IPv6 ambiguity that "localhost" resolution can introduce.
+	listenAddr := fmt.Sprintf("127.0.0.1:%d", v.Port)
+	v.logger.Debug("Starting varnishadm server on loopback", "addr", listenAddr)
+	l, err := net.Listen("tcp", listenAddr)
 	if err != nil {
-		return fmt.Errorf("net.Listen(port: %d): %w", v.Port, err)
+		return fmt.Errorf("net.Listen(%s): %w", listenAddr, err)
 	}
 	go func() {
 		<-ctx.Done()
@@ -186,7 +193,19 @@ func (v *Server) Run(ctx context.Context) error {
 	}
 }
 
-func (v *Server) handleConnection(ctx context.Context, conn net.Conn) error {
+func (v *Server) handleConnection(ctx context.Context, conn net.Conn) (returnErr error) {
+	// Recover from any panic on the connection-handling path so a malformed
+	// peer can never crash the whole chaperone. processRequest has its own
+	// recover for the post-auth command loop, but the banner/auth path
+	// (readBanner -> readFromConnection) runs before that and is otherwise
+	// unguarded; this defer covers every path in handleConnection.
+	defer func() {
+		if r := recover(); r != nil {
+			v.logger.Error("recovered from panic in handleConnection", "panic", r)
+			returnErr = fmt.Errorf("panic in handleConnection: %v", r)
+		}
+	}()
+
 	// make sure it is a TCP connection:
 	tcpConn, ok := conn.(*net.TCPConn)
 	if !ok {
@@ -550,14 +569,12 @@ func (v *Server) readFromConnection(conn *net.TCPConn, timeout time.Duration) (s
 	}
 	reader := bufio.NewReader(conn)
 
-	// Read the 13-byte header (including newline)
+	// Read the 13-byte header (including newline). io.ReadFull returns a
+	// non-nil error unless it fills the whole slice, so a nil error already
+	// guarantees exactly 13 bytes — no separate length check is needed.
 	header := make([]byte, 13)
-	n, err := io.ReadFull(reader, header)
-	if err != nil {
+	if _, err := io.ReadFull(reader, header); err != nil {
 		return "", 0, fmt.Errorf("io.ReadFull(header): %w", err)
-	}
-	if n != 13 {
-		return "", 0, fmt.Errorf("incomplete header: got %d bytes, expected 13", n)
 	}
 
 	// Validate header format
@@ -581,8 +598,12 @@ func (v *Server) readFromConnection(conn *net.TCPConn, timeout time.Duration) (s
 	if err != nil {
 		return "", 0, fmt.Errorf("invalid body length '%s': %w", lengthStr, err)
 	}
-	if err := conn.SetDeadline(deadline); err != nil {
-		return "", 0, fmt.Errorf("conn.SetDeadline(body): %w", err)
+	// Reject out-of-range lengths before allocating. A negative value (a
+	// malformed or malicious peer) would otherwise reach make([]byte, bodyLen+1)
+	// — which panics for bodyLen <= -2 — or index bodyWithNewline[bodyLen] at -1.
+	// Bounds-check both ends alongside the upper limit.
+	if bodyLen < 0 {
+		return "", 0, fmt.Errorf("invalid negative body length %d", bodyLen)
 	}
 	if bodyLen > maxResponseBodyLen {
 		return "", 0, fmt.Errorf("response body length %d exceeds maximum %d", bodyLen, maxResponseBodyLen)
@@ -593,12 +614,9 @@ func (v *Server) readFromConnection(conn *net.TCPConn, timeout time.Duration) (s
 	if err := conn.SetDeadline(deadline); err != nil {
 		return "", 0, fmt.Errorf("conn.SetDeadline(body): %w", err)
 	}
-	n, err = io.ReadFull(reader, bodyWithNewline)
+	_, err = io.ReadFull(reader, bodyWithNewline)
 	if err != nil {
 		return "", 0, fmt.Errorf("failed to read body: %w", err)
-	}
-	if n != bodyLen+1 {
-		return "", 0, fmt.Errorf("incomplete body: got %d bytes, expected %d", n, bodyLen+1)
 	}
 
 	// Validate trailing newline

--- a/internal/vcl/generator.go
+++ b/internal/vcl/generator.go
@@ -112,7 +112,16 @@ func BlockedBackendKey(routeNamespace, namespace, name string) string {
 	return routeNamespace + "/" + namespace + "/" + name
 }
 
-func CollectHTTPRouteBackends(routes []gatewayv1.HTTPRoute, gateway *gatewayv1.Gateway, namespace string, portMap ServicePortMap, blockedRefs map[string]bool) []ghost.Route {
+// routeListeners maps a route key ("namespace/name") to the set of gateway
+// listener NAMES the route is permitted to serve on. This is the authoritative
+// per-listener attachment computed by the controller — it already accounts for
+// each listener's AllowedRoutes namespace policy and hostname intersection.
+// When routeListeners is nil, or a route key is absent, CollectHTTPRouteBackends
+// falls back to the legacy sectionName/port-only computation (listenersForRoute).
+// That fallback exists only for callers without policy context (unit tests); the
+// operator always supplies routeListeners so the per-listener namespace boundary
+// is enforced.
+func CollectHTTPRouteBackends(routes []gatewayv1.HTTPRoute, gateway *gatewayv1.Gateway, namespace string, portMap ServicePortMap, blockedRefs map[string]bool, routeListeners map[string][]string) []ghost.Route {
 	var collectedRoutes []ghost.Route
 
 	ruleIndex := 0
@@ -122,11 +131,18 @@ func CollectHTTPRouteBackends(routes []gatewayv1.HTTPRoute, gateway *gatewayv1.G
 			routeNS = namespace
 		}
 
-		// Compute which listeners this route applies to
-		listeners := listenersForRoute(&route, gateway)
-
 		// Route name for X-Gateway-Route header (namespace/name)
 		routeName := routeNS + "/" + route.Name
+
+		// Compute which listeners this route applies to. Prefer the authoritative
+		// attachment set supplied by the caller (respects per-listener namespace
+		// policy); fall back to sectionName/port-only computation otherwise.
+		var listeners []string
+		if names, ok := routeListeners[routeName]; ok {
+			listeners = socketsForListenerNames(names, gateway)
+		} else {
+			listeners = listenersForRoute(&route, gateway)
+		}
 
 		// When no hostnames are specified, the route matches all hostnames.
 		// Use "*" as a sentinel that ghost VMOD treats as a catch-all.
@@ -660,6 +676,53 @@ func listenersForRoute(route *gatewayv1.HTTPRoute, gateway *gatewayv1.Gateway) [
 	}
 
 	// Build sorted result
+	var result []string
+	for s := range socketSet {
+		result = append(result, s)
+	}
+	slices.Sort(result)
+	return result
+}
+
+// socketsForListenerNames maps a set of gateway listener names to their Varnish
+// socket names. It returns nil when the given names cover ALL of the gateway's
+// listeners (nil signals "no filtering" to the ghost VMOD, i.e. serve on every
+// socket). An empty or unknown name set yields nil socket coverage — callers must
+// ensure only routes with at least one permitted listener reach here (routes that
+// attach to no listener are filtered out upstream and never programmed).
+func socketsForListenerNames(names []string, gateway *gatewayv1.Gateway) []string {
+	if gateway == nil {
+		return nil
+	}
+
+	nameSet := make(map[string]bool, len(names))
+	for _, n := range names {
+		nameSet[n] = true
+	}
+
+	socketSet := make(map[string]bool)
+	allSockets := make(map[string]bool)
+	for i := range gateway.Spec.Listeners {
+		l := &gateway.Spec.Listeners[i]
+		sock := socketNameForListener(l)
+		allSockets[sock] = true
+		if nameSet[string(l.Name)] {
+			socketSet[sock] = true
+		}
+	}
+
+	// If the permitted listeners cover every socket, no filtering is needed.
+	coversAll := len(socketSet) > 0
+	for s := range allSockets {
+		if !socketSet[s] {
+			coversAll = false
+			break
+		}
+	}
+	if coversAll {
+		return nil
+	}
+
 	var result []string
 	for s := range socketSet {
 		result = append(result, s)

--- a/internal/vcl/generator_test.go
+++ b/internal/vcl/generator_test.go
@@ -331,7 +331,7 @@ func TestCollectHTTPRouteBackends_WithPathMatches(t *testing.T) {
 		},
 	}
 
-	collectedRoutes := CollectHTTPRouteBackends(routes, nil, "default", nil, nil)
+	collectedRoutes := CollectHTTPRouteBackends(routes, nil, "default", nil, nil, nil)
 
 	if len(collectedRoutes) != 2 {
 		t.Fatalf("expected 2 routes, got %d", len(collectedRoutes))
@@ -558,7 +558,7 @@ func TestMethodMatchingConformanceFullPipeline(t *testing.T) {
 	}
 
 	// Step 1: CollectHTTPRouteBackends (what the operator does)
-	collectedRoutes := CollectHTTPRouteBackends([]gatewayv1.HTTPRoute{httpRoute}, nil, ns, nil, nil)
+	collectedRoutes := CollectHTTPRouteBackends([]gatewayv1.HTTPRoute{httpRoute}, nil, ns, nil, nil, nil)
 
 	t.Logf("CollectHTTPRouteBackends produced %d routes:", len(collectedRoutes))
 	for i, r := range collectedRoutes {
@@ -745,7 +745,7 @@ func TestCollectHTTPRouteBackends_NoMatches(t *testing.T) {
 		},
 	}
 
-	collectedRoutes := CollectHTTPRouteBackends(routes, nil, "default", nil, nil)
+	collectedRoutes := CollectHTTPRouteBackends(routes, nil, "default", nil, nil, nil)
 
 	if len(collectedRoutes) != 1 {
 		t.Fatalf("expected 1 route, got %d", len(collectedRoutes))
@@ -809,7 +809,7 @@ func TestCollectHTTPRouteBackends_PortMapResolution(t *testing.T) {
 		"default/fallback-svc:8080": {Port: 9090}, // service port 8080 → target port 9090
 	}
 
-	collectedRoutes := CollectHTTPRouteBackends(routes, nil, "default", portMap, nil)
+	collectedRoutes := CollectHTTPRouteBackends(routes, nil, "default", portMap, nil, nil)
 
 	if len(collectedRoutes) != 2 {
 		t.Fatalf("expected 2 routes, got %d", len(collectedRoutes))
@@ -888,7 +888,7 @@ func TestCollectHTTPRouteBackends_PortMapPartialResolution(t *testing.T) {
 		// unmapped-svc:9090 not in map → falls through to service port
 	}
 
-	collectedRoutes := CollectHTTPRouteBackends(routes, nil, "default", portMap, nil)
+	collectedRoutes := CollectHTTPRouteBackends(routes, nil, "default", portMap, nil, nil)
 
 	if len(collectedRoutes) != 2 {
 		t.Fatalf("expected 2 routes, got %d", len(collectedRoutes))
@@ -917,6 +917,114 @@ func TestCollectHTTPRouteBackends_PortMapPartialResolution(t *testing.T) {
 	}
 	if unmappedRoute.Port != 9090 {
 		t.Errorf("unmapped route port = %d, want 9090 (should keep service port)", unmappedRoute.Port)
+	}
+}
+
+func TestSocketsForListenerNames(t *testing.T) {
+	gateway := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "gw", Namespace: "default"},
+		Spec: gatewayv1.GatewaySpec{
+			Listeners: []gatewayv1.Listener{
+				{Name: "http-80", Port: 80, Protocol: gatewayv1.HTTPProtocolType},
+				{Name: "https-443", Port: 443, Protocol: gatewayv1.HTTPSProtocolType},
+				{Name: "http-8080", Port: 8080, Protocol: gatewayv1.HTTPProtocolType},
+			},
+		},
+	}
+
+	tests := []struct {
+		name  string
+		names []string
+		want  []string // nil means "all listeners" (no filtering)
+	}{
+		{
+			name:  "subset of listeners",
+			names: []string{"https-443"},
+			want:  []string{"https-443"},
+		},
+		{
+			name:  "two of three listeners",
+			names: []string{"http-80", "https-443"},
+			want:  []string{"http-80", "https-443"},
+		},
+		{
+			name:  "all listeners collapses to nil",
+			names: []string{"http-80", "https-443", "http-8080"},
+			want:  nil,
+		},
+		{
+			name:  "unknown listener names yield empty (not all)",
+			names: []string{"does-not-exist"},
+			want:  nil, // no matching sockets; caller must ensure this never programs a route
+		},
+		{
+			name:  "empty name set",
+			names: nil,
+			want:  nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := socketsForListenerNames(tc.names, gateway)
+			if len(tc.want) == 0 {
+				if len(got) != 0 {
+					t.Errorf("want empty/nil, got %v", got)
+				}
+				return
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("want %v, got %v", tc.want, got)
+			}
+			for i := range tc.want {
+				if got[i] != tc.want[i] {
+					t.Errorf("index %d: want %q, got %q", i, tc.want[i], got[i])
+				}
+			}
+		})
+	}
+}
+
+// TestCollectHTTPRouteBackends_RouteListenersOverride verifies the authoritative
+// per-listener attachment set supplied by the caller wins over the sectionName/port
+// computation, so the socket set respects per-listener namespace policy.
+func TestCollectHTTPRouteBackends_RouteListenersOverride(t *testing.T) {
+	gateway := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "gw", Namespace: "default"},
+		Spec: gatewayv1.GatewaySpec{
+			Listeners: []gatewayv1.Listener{
+				{Name: "http-80", Port: 80, Protocol: gatewayv1.HTTPProtocolType},
+				{Name: "http-8080", Port: 8080, Protocol: gatewayv1.HTTPProtocolType},
+			},
+		},
+	}
+	// Route has NO sectionName/port, so listenersForRoute would return nil (all
+	// sockets). The caller-supplied routeListeners restricts it to http-80 only.
+	route := gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "default"},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{{Name: "gw"}},
+			},
+			Rules: []gatewayv1.HTTPRouteRule{
+				{BackendRefs: []gatewayv1.HTTPBackendRef{{
+					BackendRef: gatewayv1.BackendRef{BackendObjectReference: gatewayv1.BackendObjectReference{
+						Name: "svc", Port: ptr(gatewayv1.PortNumber(80)),
+					}},
+				}}},
+			},
+		},
+	}
+
+	routeListeners := map[string][]string{"default/r": {"http-80"}}
+	got := CollectHTTPRouteBackends([]gatewayv1.HTTPRoute{route}, gateway, "default", nil, nil, routeListeners)
+	if len(got) == 0 {
+		t.Fatal("expected at least one collected route")
+	}
+	for _, r := range got {
+		if len(r.Listeners) != 1 || r.Listeners[0] != "http-80" {
+			t.Errorf("expected listeners [http-80], got %v", r.Listeners)
+		}
 	}
 }
 

--- a/internal/vcl/preamble.vcl
+++ b/internal/vcl/preamble.vcl
@@ -16,6 +16,25 @@ sub vcl_init {
 }
 
 sub vcl_recv {
+    # Trust boundary: strip all internal control headers from client input.
+    # Ghost and the gateway VCL trust these X-Ghost-*/X-Gateway-* headers, but
+    # they are internal signalling only. A client could otherwise spoof them
+    # (varnishd appends header slots and readers take the first slot, so a
+    # client-supplied copy would win over ours). Unset them unconditionally as
+    # the very first thing, before any routing or ghost producer runs. VCL has
+    # no wildcard unset, so every name is enumerated explicitly.
+    unset req.http.X-Ghost-Pass;
+    unset req.http.X-Ghost-Forced-TTL;
+    unset req.http.X-Ghost-Default-TTL;
+    unset req.http.X-Ghost-Grace;
+    unset req.http.X-Ghost-Keep;
+    unset req.http.X-Ghost-Cache-Key-Extra;
+    unset req.http.X-Ghost-Filter-Context;
+    unset req.http.X-Ghost-Redirect-Config;
+    unset req.http.X-Ghost-Error;
+    unset req.http.X-Gateway-Listener;
+    unset req.http.X-Gateway-Route;
+
     # Handle reload endpoint (localhost only)
     if (req.url == "/.varnish-ghost/reload" && client.ip ~ localhost) {
         if (router.reload()) {

--- a/internal/vrun/config.go
+++ b/internal/vrun/config.go
@@ -11,7 +11,7 @@ import (
 type Config struct {
 	// Required - used internally by BuildArgs
 	WorkDir   string // Secret file path is derived from this
-	AdminPort int    // -M localhost:<port>
+	AdminPort int    // -M 127.0.0.1:<port>
 
 	// Optional
 	VarnishDir string // -n argument, empty for default
@@ -48,7 +48,12 @@ func BuildArgs(cfg *Config) ([]string, error) {
 
 	secretPath := filepath.Join(cfg.WorkDir, "secret")
 	args = append(args, "-S", secretPath)
-	args = append(args, "-M", fmt.Sprintf("localhost:%d", cfg.AdminPort))
+	// Dial IPv4 loopback explicitly (not "localhost") so this matches the
+	// address the varnishadm reverse-mode server binds (127.0.0.1). Using
+	// "localhost" would risk resolving to ::1 while the server listens on
+	// 127.0.0.1, breaking the admin channel; the literal keeps both sides in
+	// agreement and the channel pod-local.
+	args = append(args, "-M", fmt.Sprintf("127.0.0.1:%d", cfg.AdminPort))
 
 	if cfg.VarnishDir != "" {
 		args = append(args, "-n", cfg.VarnishDir)

--- a/internal/vrun/process_test.go
+++ b/internal/vrun/process_test.go
@@ -115,6 +115,23 @@ func TestBuildArgs(t *testing.T) {
 	if !paramFound {
 		t.Error("Param arguments not found in args")
 	}
+
+	// Verify -M targets IPv4 loopback explicitly (H-6): the reverse-mode admin
+	// channel must stay pod-local and agree with the address the varnishadm
+	// server binds (127.0.0.1). "localhost" is deliberately avoided.
+	mFound := false
+	for i, arg := range args {
+		if arg == "-M" && i+1 < len(args) {
+			if args[i+1] != "127.0.0.1:6082" {
+				t.Errorf("-M target = %q, want 127.0.0.1:6082", args[i+1])
+			}
+			mFound = true
+			break
+		}
+	}
+	if !mFound {
+		t.Error("-M argument not found in args")
+	}
 }
 
 func TestBuildArgsWithExtraArgs(t *testing.T) {


### PR DESCRIPTION
Resolves the 10 high-severity findings from the code review. Each was independently re-verified against source before fixing; 66/69 review findings were confirmed (2 refuted, 1 by-design — tracked separately for the medium/low pass).

## High-severity fixes

| # | Finding | Fix |
|---|---------|-----|
| H-1 | Client-spoofable `X-Ghost-*`/`X-Gateway-*` internal headers | Strip all internal control headers at the top of preamble `vcl_recv` before `router.recv()`; unset-before-set in every ghost producer; clamp redirect `status_code` to {301,302,303,307,308} |
| H-2 | Unauthenticated internal HTTP surfaces | Dashboard → `127.0.0.1`; pprof/`/debug/*` → loopback `:6060`; `/drain` token-gated (per-Gateway UID token, constant-time compare); SSE-safe server timeouts; CORS `*` removed |
| H-3 | `AllowedRoutes` namespace policy enforced gateway-wide, not per-listener | Per-listener attachment (namespace + hostname intersection on the same listener) drives both status and socket set |
| H-4 | `effectiveHostnames` nil overload → non-intersecting routes as catch-all | Explicit catch-all signal; no-intersection / unresolvable sectionName drop the route instead of promoting to catch-all |
| H-5 | Stale routes left in `routing.json` on parentRef change | Regenerate + prune stale `status.Parents` for detached gateways; enqueue old+new parents on update/delete |
| H-6 | varnishadm reverse-mode listener binds all interfaces | Listener and `-M` target both `127.0.0.1` |
| H-7 | Negative CLI body length panics on unrecovered banner path | Reject `bodyLen < 0` before alloc; `recover()` on the banner path |
| H-8 | `vcl.inline` heredoc injection via bare `EOF` | Unguessable per-call crypto-random delimiter |
| H-9 | `.pem` fsnotify filter misses every Secret rotation | Reload on the atomic-writer `..data` symlink swap |
| H-10 | EventBus send-on-closed-channel panic | Stop closing subscriber channels in `Unsubscribe`; receivers exit via `ctx.Done()` |

## Deliberate deviations from the review
- **Health server not loopback-bound** (contra the review): it is the kubelet readiness-probe target, so loopback would break the probe. `/drain` is token-gated instead.
- **NetworkPolicy deferred**: listener ports are dynamic per-Gateway, so a static chart policy risks black-holing `:80`/`:443`. Loopback binding already closes the exposed surface; the right form is an operator-generated per-Gateway policy behind an opt-in Helm value.
- **Per-parentRef `Accepted` status granularity** left as follow-up — the security boundary (socket set) is fully enforced; Accepted is still computed as a union across parentRefs (pre-existing semantics).

## Verification
`gofmt` / `go vet` / `go build ./...` clean; unit tests (incl. `-race`) and the envtest integration suite pass; ghost builds with `cargo test` + clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)