### PR TITLE
fix: resolve medium-severity code-review findings

### DIFF
--- a/api/v1alpha1/varnishcacheinvalidation_types.go
+++ b/api/v1alpha1/varnishcacheinvalidation_types.go
@@ -51,12 +51,21 @@ type VarnishCacheInvalidationSpec struct {
 	Type VarnishCacheInvalidationType `json:"type"`
 
 	// Hostname is the Host header value for the invalidation request.
+	// It must be a valid RFC 1123 hostname. The constraint is also a security
+	// boundary: the hostname is concatenated into a Varnish ban expression, so
+	// disallowing whitespace, quotes and '&' prevents ban-expression injection.
+	// The chaperone re-validates this at runtime (validateInvalidationSpec).
+	// +kubebuilder:validation:MaxLength=253
+	// +kubebuilder:validation:Pattern=`^([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$`
 	Hostname string `json:"hostname"`
 
 	// Paths is the list of URL paths for the invalidation.
 	// For Purge: exact paths of cached objects (e.g., "/api/users/123").
 	// For Ban: regex patterns matching cached URLs (e.g., "/api/.*").
+	// Each path must start with '/' and contain no whitespace or quotes; the
+	// chaperone re-validates this at runtime to prevent ban-expression injection.
 	// +kubebuilder:validation:MinItems=1
+	// +kubebuilder:validation:items:Pattern=`^/[^\s"]*$`
 	Paths []string `json:"paths"`
 
 	// TTL is how long to keep this resource after all pods have completed.

--- a/charts/varnish-gateway/crds/gateway.varnish-software.com_varnishcacheinvalidations.yaml
+++ b/charts/varnish-gateway/crds/gateway.varnish-software.com_varnishcacheinvalidations.yaml
@@ -76,15 +76,24 @@ spec:
                 - name
                 type: object
               hostname:
-                description: Hostname is the Host header value for the invalidation
-                  request.
+                description: |-
+                  Hostname is the Host header value for the invalidation request.
+                  It must be a valid RFC 1123 hostname. The constraint is also a security
+                  boundary: the hostname is concatenated into a Varnish ban expression, so
+                  disallowing whitespace, quotes and '&' prevents ban-expression injection.
+                  The chaperone re-validates this at runtime (validateInvalidationSpec).
+                maxLength: 253
+                pattern: ^([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$
                 type: string
               paths:
                 description: |-
                   Paths is the list of URL paths for the invalidation.
                   For Purge: exact paths of cached objects (e.g., "/api/users/123").
                   For Ban: regex patterns matching cached URLs (e.g., "/api/.*").
+                  Each path must start with '/' and contain no whitespace or quotes; the
+                  chaperone re-validates this at runtime to prevent ban-expression injection.
                 items:
+                  pattern: ^/[^\s"]*$
                   type: string
                 minItems: 1
                 type: array

--- a/deploy/00-prereqs.yaml
+++ b/deploy/00-prereqs.yaml
@@ -4328,15 +4328,24 @@ spec:
                 - name
                 type: object
               hostname:
-                description: Hostname is the Host header value for the invalidation
-                  request.
+                description: |-
+                  Hostname is the Host header value for the invalidation request.
+                  It must be a valid RFC 1123 hostname. The constraint is also a security
+                  boundary: the hostname is concatenated into a Varnish ban expression, so
+                  disallowing whitespace, quotes and '&' prevents ban-expression injection.
+                  The chaperone re-validates this at runtime (validateInvalidationSpec).
+                maxLength: 253
+                pattern: ^([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$
                 type: string
               paths:
                 description: |-
                   Paths is the list of URL paths for the invalidation.
                   For Purge: exact paths of cached objects (e.g., "/api/users/123").
                   For Ban: regex patterns matching cached URLs (e.g., "/api/.*").
+                  Each path must start with '/' and contain no whitespace or quotes; the
+                  chaperone re-validates this at runtime to prevent ban-expression injection.
                 items:
+                  pattern: ^/[^\s"]*$
                   type: string
                 minItems: 1
                 type: array

--- a/ghost/src/external_backend.rs
+++ b/ghost/src/external_backend.rs
@@ -201,7 +201,7 @@ impl VclBackend<ExternalBody> for ExternalBackend {
             let p = sob_to_str(bereq.url())?.to_string();
             let headers: Vec<(String, Vec<u8>)> = bereq
                 .into_iter()
-                .filter(|(k, _)| !is_hop_by_hop(k))
+                .filter(|(k, _)| forward_client_header(k))
                 .map(|(k, v)| (k.to_string(), v.as_ref().to_vec()))
                 .collect();
             (p, headers)
@@ -397,6 +397,20 @@ fn is_hop_by_hop(name: &str) -> bool {
     HOP_BY_HOP.iter().any(|h| name.eq_ignore_ascii_case(h))
 }
 
+/// Whether a client (bereq) header should be copied verbatim onto the
+/// upstream reqwest request.
+///
+/// Hop-by-hop headers are dropped per RFC 7230. `Host` is dropped too: it is
+/// NOT hop-by-hop, so without this guard it would be copied here and then a
+/// SECOND `Host` appended by `req_builder.header("host", ...)` — reqwest's
+/// `.header()` appends rather than replaces, so two conflicting `Host:` lines
+/// would go on the wire (client value first). Strict upstreams reject that
+/// (nginx 400; S3/GCS SigV4 signature mismatch). The upstream `Host` is set
+/// exactly once, from `self.upstream_host`.
+fn forward_client_header(name: &str) -> bool {
+    !is_hop_by_hop(name) && !name.eq_ignore_ascii_case("host")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -408,6 +422,25 @@ mod tests {
         assert!(is_hop_by_hop("Transfer-Encoding"));
         assert!(!is_hop_by_hop("Content-Type"));
         assert!(!is_hop_by_hop("Host"));
+    }
+
+    #[test]
+    fn forward_client_header_drops_host_and_hop_by_hop() {
+        // Host must be dropped so it isn't duplicated with the explicit
+        // upstream Host set later (reqwest `.header()` appends).
+        assert!(!forward_client_header("Host"));
+        assert!(!forward_client_header("host"));
+        assert!(!forward_client_header("HOST"));
+
+        // Hop-by-hop headers are still dropped.
+        assert!(!forward_client_header("Connection"));
+        assert!(!forward_client_header("transfer-encoding"));
+
+        // Ordinary end-to-end headers are forwarded.
+        assert!(forward_client_header("Accept"));
+        assert!(forward_client_header("User-Agent"));
+        assert!(forward_client_header("Authorization"));
+        assert!(forward_client_header("X-Amz-Date"));
     }
 
     #[test]

--- a/internal/controller/backendtls_attach_test.go
+++ b/internal/controller/backendtls_attach_test.go
@@ -1,0 +1,277 @@
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/varnish/gateway/internal/ghost"
+)
+
+// backendTLSPolicy is a small helper to build a BackendTLSPolicy targeting a
+// Service (optionally scoped to a Service port via sectionName) with a hostname.
+func backendTLSPolicy(name, ns, service, section, hostname string, created metav1.Time, validation gatewayv1.BackendTLSPolicyValidation) *gatewayv1.BackendTLSPolicy {
+	targetRef := gatewayv1.LocalPolicyTargetReferenceWithSectionName{
+		LocalPolicyTargetReference: gatewayv1.LocalPolicyTargetReference{Kind: "Service", Name: gatewayv1.ObjectName(service)},
+	}
+	if section != "" {
+		s := gatewayv1.SectionName(section)
+		targetRef.SectionName = &s
+	}
+	validation.Hostname = gatewayv1.PreciseHostname(hostname)
+	return &gatewayv1.BackendTLSPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns, CreationTimestamp: created},
+		Spec: gatewayv1.BackendTLSPolicySpec{
+			TargetRefs: []gatewayv1.LocalPolicyTargetReferenceWithSectionName{targetRef},
+			Validation: validation,
+		},
+	}
+}
+
+// systemValidation returns a validation block that always resolves.
+func systemValidation() gatewayv1.BackendTLSPolicyValidation {
+	wk := gatewayv1.WellKnownCACertificatesSystem
+	return gatewayv1.BackendTLSPolicyValidation{WellKnownCACertificates: &wk}
+}
+
+// M-5: the data-plane winner must match the GEP-713 precedence winner (oldest
+// creationTimestamp), not depend on List iteration order.
+func TestAttachBackendTLS_PrecedenceOldestWins(t *testing.T) {
+	scheme := newTestScheme()
+	now := metav1.Now()
+	later := metav1.NewTime(now.Add(time.Second))
+
+	// Two policies target the same Service with no sectionName. The older one wins.
+	older := backendTLSPolicy("aaa-newer-name-but-older", "default", "svc", "", "older.example.com", now, systemValidation())
+	newer := backendTLSPolicy("zzz-older-name-but-newer", "default", "svc", "", "newer.example.com", later, systemValidation())
+
+	// Provide them in the "wrong" order (newer first) to prove ordering is applied.
+	r := newHTTPRouteTestReconciler(scheme, newer, older)
+
+	routes := []ghost.Route{{Namespace: "default", Service: "svc", Port: 8080}}
+	r.attachBackendTLS(context.Background(), routes)
+
+	if routes[0].BackendTLS == nil {
+		t.Fatal("expected BackendTLS to be attached")
+	}
+	if routes[0].BackendTLS.Hostname != "older.example.com" {
+		t.Errorf("expected older policy to win, got hostname %q", routes[0].BackendTLS.Hostname)
+	}
+}
+
+// M-5: with equal timestamps, the alphabetically-first namespace/name wins.
+func TestAttachBackendTLS_PrecedenceAlphabeticalTiebreak(t *testing.T) {
+	scheme := newTestScheme()
+	ts := metav1.Now()
+
+	a := backendTLSPolicy("policy-a", "default", "svc", "", "a.example.com", ts, systemValidation())
+	b := backendTLSPolicy("policy-b", "default", "svc", "", "b.example.com", ts, systemValidation())
+
+	r := newHTTPRouteTestReconciler(scheme, b, a)
+
+	routes := []ghost.Route{{Namespace: "default", Service: "svc", Port: 8080}}
+	r.attachBackendTLS(context.Background(), routes)
+
+	if routes[0].BackendTLS == nil || routes[0].BackendTLS.Hostname != "a.example.com" {
+		t.Errorf("expected policy-a to win alphabetical tiebreak, got %+v", routes[0].BackendTLS)
+	}
+}
+
+// M-6: a section-scoped policy applies only to the route hitting that Service
+// port; a section-less policy applies to the other port.
+func TestAttachBackendTLS_SectionNameScoping(t *testing.T) {
+	scheme := newTestScheme()
+	ts := metav1.Now()
+
+	// Service with two named ports mapping to distinct target ports.
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "default"},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{Name: "web", Port: 80, TargetPort: intstr.FromInt(8080)},
+				{Name: "admin", Port: 9090, TargetPort: intstr.FromInt(9091)},
+			},
+		},
+	}
+
+	// Section-scoped to "web" and a service-wide policy.
+	webPolicy := backendTLSPolicy("web-policy", "default", "svc", "web", "web.example.com", ts, systemValidation())
+	widePolicy := backendTLSPolicy("wide-policy", "default", "svc", "", "wide.example.com", ts, systemValidation())
+
+	r := newHTTPRouteTestReconciler(scheme, svc, webPolicy, widePolicy)
+
+	// Route hitting target port 8080 ("web") and one hitting 9091 ("admin").
+	routes := []ghost.Route{
+		{Namespace: "default", Service: "svc", Port: 8080}, // web
+		{Namespace: "default", Service: "svc", Port: 9091}, // admin
+	}
+	r.attachBackendTLS(context.Background(), routes)
+
+	if routes[0].BackendTLS == nil || routes[0].BackendTLS.Hostname != "web.example.com" {
+		t.Errorf("web route: expected section-scoped policy, got %+v", routes[0].BackendTLS)
+	}
+	// admin port has no section-scoped policy, so the service-wide one applies.
+	if routes[1].BackendTLS == nil || routes[1].BackendTLS.Hostname != "wide.example.com" {
+		t.Errorf("admin route: expected service-wide policy, got %+v", routes[1].BackendTLS)
+	}
+}
+
+// M-6: a port-specific policy must NOT leak onto other ports when no service-wide
+// policy exists.
+func TestAttachBackendTLS_SectionScopedDoesNotLeak(t *testing.T) {
+	scheme := newTestScheme()
+	ts := metav1.Now()
+
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "default"},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{Name: "web", Port: 80, TargetPort: intstr.FromInt(8080)},
+				{Name: "admin", Port: 9090, TargetPort: intstr.FromInt(9091)},
+			},
+		},
+	}
+	webPolicy := backendTLSPolicy("web-policy", "default", "svc", "web", "web.example.com", ts, systemValidation())
+
+	r := newHTTPRouteTestReconciler(scheme, svc, webPolicy)
+
+	routes := []ghost.Route{
+		{Namespace: "default", Service: "svc", Port: 9091}, // admin — no matching policy
+	}
+	r.attachBackendTLS(context.Background(), routes)
+
+	if routes[0].BackendTLS != nil {
+		t.Errorf("admin route should not get the web-scoped policy, got %+v", routes[0].BackendTLS)
+	}
+}
+
+// M-6: a route with a named targetPort carries PortName directly; the section
+// match should use it without needing a Service lookup.
+func TestAttachBackendTLS_SectionNameFromRoutePortName(t *testing.T) {
+	scheme := newTestScheme()
+	ts := metav1.Now()
+
+	webPolicy := backendTLSPolicy("web-policy", "default", "svc", "web", "web.example.com", ts, systemValidation())
+	r := newHTTPRouteTestReconciler(scheme, webPolicy)
+
+	routes := []ghost.Route{
+		{Namespace: "default", Service: "svc", Port: 0, PortName: "web"},
+	}
+	r.attachBackendTLS(context.Background(), routes)
+
+	if routes[0].BackendTLS == nil || routes[0].BackendTLS.Hostname != "web.example.com" {
+		t.Errorf("expected section match via PortName, got %+v", routes[0].BackendTLS)
+	}
+}
+
+// M-7: a policy whose caCertificateRefs don't resolve must be skipped — backend
+// TLS must not be enabled for a policy that can't verify.
+func TestAttachBackendTLS_UnresolvableCARefSkipped(t *testing.T) {
+	scheme := newTestScheme()
+	ts := metav1.Now()
+
+	// Policy references a ConfigMap that does not exist.
+	badPolicy := backendTLSPolicy("bad", "default", "svc", "", "bad.example.com", ts,
+		gatewayv1.BackendTLSPolicyValidation{
+			CACertificateRefs: []gatewayv1.LocalObjectReference{{Kind: "ConfigMap", Name: "missing-ca"}},
+		})
+
+	r := newHTTPRouteTestReconciler(scheme, badPolicy)
+
+	routes := []ghost.Route{{Namespace: "default", Service: "svc", Port: 8080}}
+	r.attachBackendTLS(context.Background(), routes)
+
+	if routes[0].BackendTLS != nil {
+		t.Errorf("expected unresolvable policy to be skipped, got %+v", routes[0].BackendTLS)
+	}
+}
+
+// M-7 + M-5: when an unresolvable policy has precedence over a resolvable one,
+// the resolvable one must still be programmed (the unresolvable never enters the
+// candidate set).
+func TestAttachBackendTLS_ResolvableWinsOverUnresolvable(t *testing.T) {
+	scheme := newTestScheme()
+	now := metav1.Now()
+	later := metav1.NewTime(now.Add(time.Second))
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "good-ca", Namespace: "default"},
+		Data:       map[string]string{caCertKey: testPEM},
+	}
+	// Older policy is unresolvable (missing CM); newer is resolvable.
+	bad := backendTLSPolicy("bad-older", "default", "svc", "", "bad.example.com", now,
+		gatewayv1.BackendTLSPolicyValidation{
+			CACertificateRefs: []gatewayv1.LocalObjectReference{{Kind: "ConfigMap", Name: "missing-ca"}},
+		})
+	good := backendTLSPolicy("good-newer", "default", "svc", "", "good.example.com", later,
+		gatewayv1.BackendTLSPolicyValidation{
+			CACertificateRefs: []gatewayv1.LocalObjectReference{{Kind: "ConfigMap", Name: "good-ca"}},
+		})
+
+	r := newHTTPRouteTestReconciler(scheme, cm, bad, good)
+
+	routes := []ghost.Route{{Namespace: "default", Service: "svc", Port: 8080}}
+	r.attachBackendTLS(context.Background(), routes)
+
+	if routes[0].BackendTLS == nil || routes[0].BackendTLS.Hostname != "good.example.com" {
+		t.Errorf("expected resolvable policy to be programmed, got %+v", routes[0].BackendTLS)
+	}
+}
+
+// A route whose Service is not targeted by any policy gets no BackendTLS.
+func TestAttachBackendTLS_NoMatchingPolicy(t *testing.T) {
+	scheme := newTestScheme()
+	ts := metav1.Now()
+
+	policy := backendTLSPolicy("p", "default", "other-svc", "", "example.com", ts, systemValidation())
+	r := newHTTPRouteTestReconciler(scheme, policy)
+
+	routes := []ghost.Route{{Namespace: "default", Service: "svc", Port: 8080}}
+	r.attachBackendTLS(context.Background(), routes)
+
+	if routes[0].BackendTLS != nil {
+		t.Errorf("expected no BackendTLS for unmatched service, got %+v", routes[0].BackendTLS)
+	}
+}
+
+// resolveServicePortName maps a numeric target port back to the Service port name.
+func TestResolveServicePortName(t *testing.T) {
+	scheme := newTestScheme()
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "default"},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{Name: "web", Port: 80, TargetPort: intstr.FromInt(8080)},
+				{Name: "plain", Port: 8081}, // targetPort defaults to Port
+			},
+		},
+	}
+	r := newHTTPRouteTestReconciler(scheme, svc)
+	cache := make(map[types.NamespacedName]map[int]string)
+
+	tests := []struct {
+		name  string
+		route ghost.Route
+		want  string
+	}{
+		{"named-targetport-uses-portname", ghost.Route{Namespace: "default", Service: "svc", PortName: "web"}, "web"},
+		{"numeric-targetport-maps-to-name", ghost.Route{Namespace: "default", Service: "svc", Port: 8080}, "web"},
+		{"default-targetport-maps-to-name", ghost.Route{Namespace: "default", Service: "svc", Port: 8081}, "plain"},
+		{"unknown-port-empty", ghost.Route{Namespace: "default", Service: "svc", Port: 9999}, ""},
+		{"missing-service-empty", ghost.Route{Namespace: "default", Service: "nope", Port: 80}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := r.resolveServicePortName(context.Background(), &tt.route, cache)
+			if got != tt.want {
+				t.Errorf("resolveServicePortName = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/controller/backendtlspolicy_controller.go
+++ b/internal/controller/backendtlspolicy_controller.go
@@ -122,6 +122,15 @@ func (r *BackendTLSPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Req
 // validateCACertificateRefs checks all CA certificate references in the policy.
 // Returns (resolved, reason, message).
 func (r *BackendTLSPolicyReconciler) validateCACertificateRefs(ctx context.Context, policy *gatewayv1.BackendTLSPolicy) (bool, string, string) {
+	return validateBackendTLSCACerts(ctx, r.Client, policy)
+}
+
+// validateBackendTLSCACerts checks all CA certificate references in the policy and
+// reports whether they resolve to valid PEM data (or the policy uses
+// WellKnownCACertificates: System). It is shared by the BackendTLSPolicy status
+// reconciler and the HTTPRoute data-plane attach path so the two never disagree
+// about which policies are usable. Returns (resolved, reason, message).
+func validateBackendTLSCACerts(ctx context.Context, c client.Client, policy *gatewayv1.BackendTLSPolicy) (bool, string, string) {
 	// WellKnownCACertificates: System is always valid
 	if policy.Spec.Validation.WellKnownCACertificates != nil &&
 		*policy.Spec.Validation.WellKnownCACertificates == gatewayv1.WellKnownCACertificatesSystem {
@@ -142,7 +151,7 @@ func (r *BackendTLSPolicyReconciler) validateCACertificateRefs(ctx context.Conte
 
 		// Check that the ConfigMap exists and contains a ca.crt key
 		var cm corev1.ConfigMap
-		if err := r.Get(ctx, types.NamespacedName{
+		if err := c.Get(ctx, types.NamespacedName{
 			Name:      string(ref.Name),
 			Namespace: policy.Namespace,
 		}, &cm); err != nil {

--- a/internal/controller/gateway_controller.go
+++ b/internal/controller/gateway_controller.go
@@ -241,6 +241,7 @@ func (r *GatewayReconciler) reconcileResources(ctx context.Context, gateway *gat
 		ExtraInitContainers:       extraInitContainers,
 		TopologySpreadConstraints: topologySpread,
 		HasBackendTLS:             hasBackendTLS,
+		Resources:                 containerResources,
 	}
 	infraHash := infraConfig.ComputeHash()
 
@@ -365,6 +366,12 @@ func (r *GatewayReconciler) reconcileResource(ctx context.Context, gateway *gate
 		existingCM := existing.(*corev1.ConfigMap)
 		// Check if main.vcl changed
 		if existingCM.Data["main.vcl"] != desiredCM.Data["main.vcl"] {
+			// A pre-existing ConfigMap (e.g. one a user created by hand before
+			// the Gateway) can have a nil Data map; assigning into a nil map
+			// panics, so materialize it first.
+			if existingCM.Data == nil {
+				existingCM.Data = map[string]string{}
+			}
 			// Update only main.vcl, keep routing.json from existing
 			existingCM.Data["main.vcl"] = desiredCM.Data["main.vcl"]
 			if err := r.Update(ctx, existingCM); err != nil {
@@ -858,30 +865,50 @@ func (r *GatewayReconciler) setListenerStatusesForUpdate(ctx context.Context, up
 			}
 		}
 
-		conditions := []metav1.Condition{
-			{
-				Type:               string(gatewayv1.ListenerConditionAccepted),
-				Status:             metav1.ConditionTrue,
-				ObservedGeneration: updated.Generation,
-				LastTransitionTime: acceptedTime,
-				Reason:             string(gatewayv1.ListenerReasonAccepted),
-				Message:            "Listener accepted",
-			},
-			{
-				Type:               string(gatewayv1.ListenerConditionProgrammed),
-				Status:             metav1.ConditionTrue,
-				ObservedGeneration: updated.Generation,
-				LastTransitionTime: programmedTime,
-				Reason:             string(gatewayv1.ListenerReasonProgrammed),
-				Message:            "Listener programmed",
-			},
+		acceptedCond := metav1.Condition{
+			Type:               string(gatewayv1.ListenerConditionAccepted),
+			Status:             metav1.ConditionTrue,
+			ObservedGeneration: updated.Generation,
+			LastTransitionTime: acceptedTime,
+			Reason:             string(gatewayv1.ListenerReasonAccepted),
+			Message:            "Listener accepted",
 		}
+		programmedCond := metav1.Condition{
+			Type:               string(gatewayv1.ListenerConditionProgrammed),
+			Status:             metav1.ConditionTrue,
+			ObservedGeneration: updated.Generation,
+			LastTransitionTime: programmedTime,
+			Reason:             string(gatewayv1.ListenerReasonProgrammed),
+			Message:            "Listener programmed",
+		}
+
+		// Reject listeners whose port collides with an internal data-plane bind
+		// (ghost reload, varnishadm, health, dashboard, pprof). Programming such
+		// a listener would crash-loop the pod, so we mark it Accepted=False
+		// (PortUnavailable) and never program it (see buildGatewayContainer).
+		if desc, reserved := reservedContainerPorts[int32(listener.Port)]; reserved {
+			msg := fmt.Sprintf("Listener port %d is reserved for internal data-plane use (%s)", listener.Port, desc)
+			acceptedCond.Status = metav1.ConditionFalse
+			acceptedCond.Reason = string(gatewayv1.ListenerReasonPortUnavailable)
+			acceptedCond.Message = msg
+			acceptedCond.LastTransitionTime = metav1.Now()
+			programmedCond.Status = metav1.ConditionFalse
+			programmedCond.Reason = string(gatewayv1.ListenerReasonInvalid)
+			programmedCond.Message = msg
+			programmedCond.LastTransitionTime = metav1.Now()
+		}
+
+		conditions := []metav1.Condition{acceptedCond, programmedCond}
 
 		// Determine supported kinds and validate allowed route kinds
 		supportedKinds, hasInvalidKinds := validateListenerRouteKinds(&listener)
 
-		// Add ResolvedRefs condition for route kind validation
-		if hasInvalidKinds {
+		// Emit exactly one ResolvedRefs condition per listener. ListenerStatus.Conditions
+		// is a +listType=map keyed by Type, so two ResolvedRefs entries would make the
+		// API server reject the status patch and wedge reconcile in a backoff loop.
+		// Precedence: invalid route kinds > HTTPS TLS ref validation > default (resolved).
+		switch {
+		case hasInvalidKinds:
 			conditions = append(conditions, metav1.Condition{
 				Type:               string(gatewayv1.ListenerConditionResolvedRefs),
 				Status:             metav1.ConditionFalse,
@@ -890,17 +917,11 @@ func (r *GatewayReconciler) setListenerStatusesForUpdate(ctx context.Context, up
 				Reason:             string(gatewayv1.ListenerReasonInvalidRouteKinds),
 				Message:            "One or more route kinds are not supported",
 			})
-		}
-
-		// Add ResolvedRefs condition for HTTPS listeners
-		if listener.Protocol == gatewayv1.HTTPSProtocolType {
-			resolvedRefs := r.validateListenerTLSRefs(ctx, updated, &listener)
-			conditions = append(conditions, resolvedRefs)
-		}
-
-		// Add ResolvedRefs: True for non-HTTPS listeners that don't already have it
-		// (e.g., HTTP listeners). The spec requires ResolvedRefs on all listeners.
-		if !hasInvalidKinds && listener.Protocol != gatewayv1.HTTPSProtocolType {
+		case listener.Protocol == gatewayv1.HTTPSProtocolType:
+			conditions = append(conditions, r.validateListenerTLSRefs(ctx, updated, &listener))
+		default:
+			// ResolvedRefs: True for non-HTTPS listeners (e.g. HTTP). The spec
+			// requires ResolvedRefs on all listeners.
 			resolvedRefsTime := metav1.Now()
 			if hasExisting {
 				for _, c := range existing.Conditions {
@@ -1490,6 +1511,39 @@ func (r *GatewayReconciler) gatewayRequestsForClassNames(ctx context.Context, cl
 	return requests, nil
 }
 
+// enqueueGatewaysForGatewayClass returns an EventHandler that enqueues all
+// Gateways whose spec.gatewayClassName matches a changed GatewayClass managed
+// by our controller.
+//
+// Without this watch, a Gateway persisted before its GatewayClass (e.g. a
+// multi-doc manifest applied in one shot, or a later-created GatewayClass /
+// parametersRef) would sit unreconciled: Reconcile early-returns when the class
+// is missing or not ours, the manager has no SyncPeriod, and nothing re-enqueues
+// the Gateway until an unrelated watched object happens to change or the operator
+// restarts.
+func (r *GatewayReconciler) enqueueGatewaysForGatewayClass() handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []ctrl.Request {
+		gc, ok := obj.(*gatewayv1.GatewayClass)
+		if !ok {
+			return nil
+		}
+		// Only react to classes we own — matches the Reconcile guard.
+		if string(gc.Spec.ControllerName) != ControllerName {
+			return nil
+		}
+		requests, err := r.gatewayRequestsForClassNames(ctx, map[string]struct{}{gc.Name: {}})
+		if err != nil {
+			r.Logger.Error("failed to list Gateways for GatewayClass change", "gatewayClass", gc.Name, "error", err)
+			return nil
+		}
+		if len(requests) > 0 {
+			r.Logger.Info("GatewayClass changed, enqueuing Gateways for reconciliation",
+				"gatewayClass", gc.Name, "gateways", len(requests))
+		}
+		return requests
+	})
+}
+
 // enqueueGatewaysForParams returns an EventHandler that enqueues all Gateways
 // that use a GatewayClass referencing the changed GatewayClassParameters.
 func (r *GatewayReconciler) enqueueGatewaysForParams() handler.EventHandler {
@@ -1895,6 +1949,10 @@ func (r *GatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&policyv1.PodDisruptionBudget{}).
 		// Note: ClusterRoleBinding is cluster-scoped, so it cannot be owned by namespace-scoped Gateway
 		// We manage its lifecycle manually in reconcileResources without owner references
+		Watches(
+			&gatewayv1.GatewayClass{},
+			r.enqueueGatewaysForGatewayClass(),
+		).
 		Watches(
 			&gatewayv1.HTTPRoute{},
 			r.enqueueGatewaysForHTTPRoute(),

--- a/internal/controller/gateway_controller_test.go
+++ b/internal/controller/gateway_controller_test.go
@@ -3491,6 +3491,171 @@ func keys[V any](m map[string]V) []string {
 	return result
 }
 
+// countConditionsOfType returns how many conditions in the slice have the given
+// type. Used to guard against duplicate map-keyed conditions (which make the API
+// server reject a status patch).
+func countConditionsOfType(conditions []metav1.Condition, condType string) int {
+	n := 0
+	for _, c := range conditions {
+		if c.Type == condType {
+			n++
+		}
+	}
+	return n
+}
+
+// TestEnqueueGatewaysForGatewayClass covers M-1: a Gateway persisted before its
+// GatewayClass (or before a later parametersRef) must be reconciled once the
+// GatewayClass appears/changes.
+func TestEnqueueGatewaysForGatewayClass(t *testing.T) {
+	scheme := newTestScheme()
+	ctx := context.Background()
+
+	t.Run("changed GatewayClass enqueues matching Gateways", func(t *testing.T) {
+		gw := &gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{Name: "gw", Namespace: "default"},
+			Spec:       gatewayv1.GatewaySpec{GatewayClassName: "varnish"},
+		}
+		other := &gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{Name: "other", Namespace: "default"},
+			Spec:       gatewayv1.GatewaySpec{GatewayClassName: "somethingelse"},
+		}
+		r := newTestReconciler(scheme, gw, other)
+		h := r.enqueueGatewaysForGatewayClass()
+
+		gc := newTestGatewayClass("varnish")
+		requests := extractRequests(t, h, ctx, gc)
+		if len(requests) != 1 {
+			t.Fatalf("expected 1 request, got %d", len(requests))
+		}
+		if requests[0].Name != "gw" {
+			t.Errorf("expected request for 'gw', got %q", requests[0].Name)
+		}
+	})
+
+	t.Run("GatewayClass with foreign controllerName is ignored", func(t *testing.T) {
+		gw := &gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{Name: "gw", Namespace: "default"},
+			Spec:       gatewayv1.GatewaySpec{GatewayClassName: "foreign"},
+		}
+		r := newTestReconciler(scheme, gw)
+		h := r.enqueueGatewaysForGatewayClass()
+
+		gc := &gatewayv1.GatewayClass{
+			ObjectMeta: metav1.ObjectMeta{Name: "foreign"},
+			Spec:       gatewayv1.GatewayClassSpec{ControllerName: "example.com/other-controller"},
+		}
+		requests := extractRequests(t, h, ctx, gc)
+		if len(requests) != 0 {
+			t.Errorf("expected 0 requests for foreign controllerName, got %d", len(requests))
+		}
+	})
+}
+
+// TestSetListenerStatuses_SingleResolvedRefs covers M-3: an HTTPS listener with an
+// invalid route kind must not emit two ResolvedRefs conditions (duplicate map keys
+// make the status patch fail and wedge reconcile).
+func TestSetListenerStatuses_SingleResolvedRefs(t *testing.T) {
+	scheme := newTestScheme()
+	ctx := context.Background()
+
+	tlsMode := gatewayv1.TLSModeTerminate
+	secret := newTestTLSSecret("my-cert", "default")
+	r := newTestReconciler(scheme, secret)
+	original := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "gw", Namespace: "default", Generation: 1},
+		Spec: gatewayv1.GatewaySpec{
+			Listeners: []gatewayv1.Listener{
+				{
+					Name: "https", Port: 443, Protocol: gatewayv1.HTTPSProtocolType,
+					TLS: &gatewayv1.ListenerTLSConfig{
+						Mode:            &tlsMode,
+						CertificateRefs: []gatewayv1.SecretObjectReference{{Name: "my-cert"}},
+					},
+					AllowedRoutes: &gatewayv1.AllowedRoutes{
+						Kinds: []gatewayv1.RouteGroupKind{{Kind: "TCPRoute"}},
+					},
+				},
+			},
+		},
+	}
+	updated := original.DeepCopy()
+	r.setListenerStatusesForUpdate(ctx, updated, original)
+
+	if len(updated.Status.Listeners) != 1 {
+		t.Fatalf("expected 1 listener status, got %d", len(updated.Status.Listeners))
+	}
+	conds := updated.Status.Listeners[0].Conditions
+	if got := countConditionsOfType(conds, string(gatewayv1.ListenerConditionResolvedRefs)); got != 1 {
+		t.Fatalf("expected exactly 1 ResolvedRefs condition, got %d", got)
+	}
+	condMap := conditionsToMap(conds)
+	assertConditionFalse(t, condMap, string(gatewayv1.ListenerConditionResolvedRefs))
+	if condMap[string(gatewayv1.ListenerConditionResolvedRefs)].Reason != string(gatewayv1.ListenerReasonInvalidRouteKinds) {
+		t.Errorf("expected InvalidRouteKinds reason, got %q", condMap[string(gatewayv1.ListenerConditionResolvedRefs)].Reason)
+	}
+}
+
+// TestSetListenerStatuses_ReservedPort covers M-11: a listener whose port collides
+// with an internal data-plane bind must be marked Accepted=False (PortUnavailable)
+// instead of being programmed.
+func TestSetListenerStatuses_ReservedPort(t *testing.T) {
+	scheme := newTestScheme()
+	ctx := context.Background()
+
+	r := newTestReconciler(scheme)
+	original := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "gw", Namespace: "default", Generation: 1},
+		Spec: gatewayv1.GatewaySpec{
+			Listeners: []gatewayv1.Listener{
+				{Name: "bad", Port: 8081, Protocol: gatewayv1.HTTPProtocolType},
+			},
+		},
+	}
+	updated := original.DeepCopy()
+	r.setListenerStatusesForUpdate(ctx, updated, original)
+
+	ls := updated.Status.Listeners[0]
+	condMap := conditionsToMap(ls.Conditions)
+	assertConditionFalse(t, condMap, string(gatewayv1.ListenerConditionAccepted))
+	assertConditionFalse(t, condMap, string(gatewayv1.ListenerConditionProgrammed))
+	if condMap[string(gatewayv1.ListenerConditionAccepted)].Reason != string(gatewayv1.ListenerReasonPortUnavailable) {
+		t.Errorf("expected PortUnavailable reason, got %q", condMap[string(gatewayv1.ListenerConditionAccepted)].Reason)
+	}
+}
+
+// TestReconcileResource_NilConfigMapData covers M-4: writing main.vcl into a
+// pre-existing ConfigMap with a nil Data map must not panic.
+func TestReconcileResource_NilConfigMapData(t *testing.T) {
+	scheme := newTestScheme()
+	ctx := context.Background()
+
+	gw := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "gw", Namespace: "default", UID: "test-uid"},
+		Spec:       gatewayv1.GatewaySpec{GatewayClassName: "varnish"},
+	}
+	// Pre-existing ConfigMap with no Data (nil map), e.g. `kubectl create configmap gw-vcl`.
+	existingCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "gw-vcl", Namespace: "default"},
+	}
+	r := newTestReconciler(scheme, gw, existingCM)
+
+	desiredCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "gw-vcl", Namespace: "default"},
+		Data:       map[string]string{"main.vcl": "vcl 4.1;"},
+	}
+	if err := r.reconcileResource(ctx, gw, desiredCM); err != nil {
+		t.Fatalf("unexpected error (or panic if Data was nil): %v", err)
+	}
+	var check corev1.ConfigMap
+	if err := r.Get(ctx, types.NamespacedName{Name: "gw-vcl", Namespace: "default"}, &check); err != nil {
+		t.Fatalf("failed to get configmap: %v", err)
+	}
+	if check.Data["main.vcl"] != "vcl 4.1;" {
+		t.Errorf("expected main.vcl to be written, got %q", check.Data["main.vcl"])
+	}
+}
+
 // conditionsToMap converts a slice of conditions to a map keyed by type.
 func conditionsToMap(conditions []metav1.Condition) map[string]metav1.Condition {
 	m := make(map[string]metav1.Condition)

--- a/internal/controller/httproute_controller.go
+++ b/internal/controller/httproute_controller.go
@@ -822,8 +822,31 @@ func (r *HTTPRouteReconciler) attachCachePolicies(ctx context.Context, collected
 	}
 }
 
+// backendTLSKey identifies the scope a BackendTLSPolicy applies to: a Service in a
+// namespace, optionally narrowed to a single Service port (section). An empty
+// section means the policy targets every port of the Service.
+type backendTLSKey struct {
+	namespace string
+	service   string
+	section   string
+}
+
 // attachBackendTLS resolves BackendTLSPolicies for each collected route.
 // It looks up policies targeting the route's backend Service and attaches TLS config.
+//
+// The winning policy for each (Service, port) scope is chosen so the data plane
+// agrees with the status reconciler:
+//   - GEP-713 precedence: among policies contending for the same scope, the oldest
+//     (then alphabetically first) wins — matching policyHasPrecedence / the
+//     Conflicted status. Cache-backed List order is nondeterministic, so we must
+//     not rely on last-write-wins (M-5).
+//   - sectionName scoping: targetRef.SectionName pins a policy to a single Service
+//     port name. Section-scoped policies apply only to routes hitting that port;
+//     section-less policies apply only where no section-scoped policy matches
+//     (mirrors targetRefsConflict) (M-6).
+//   - resolvability: policies whose CA references don't resolve are skipped, so we
+//     never enable backend TLS that can't verify — which would 502 every request
+//     while routing.json claimed the policy was in effect (M-7).
 func (r *HTTPRouteReconciler) attachBackendTLS(ctx context.Context, collectedRoutes []ghost.Route) {
 	// Collect unique namespaces from routes
 	namespaces := make(map[string]struct{})
@@ -831,10 +854,10 @@ func (r *HTTPRouteReconciler) attachBackendTLS(ctx context.Context, collectedRou
 		namespaces[route.Namespace] = struct{}{}
 	}
 
-	// Build lookup: "namespace/serviceName" → BackendTLSPolicy
-	// Only include policies that have valid CA cert configuration (either
-	// wellKnownCACertificates: System or valid caCertificateRefs).
-	policyMap := make(map[string]*gatewayv1.BackendTLSPolicy)
+	// Build lookup: scope → winning BackendTLSPolicy. Only policies with resolvable
+	// CA configuration are considered, and among policies contending for the same
+	// scope the one with GEP-713 precedence wins.
+	policyMap := make(map[backendTLSKey]*gatewayv1.BackendTLSPolicy)
 	for ns := range namespaces {
 		var policyList gatewayv1.BackendTLSPolicyList
 		if err := r.List(ctx, &policyList, client.InNamespace(ns)); err != nil {
@@ -844,14 +867,13 @@ func (r *HTTPRouteReconciler) attachBackendTLS(ctx context.Context, collectedRou
 		for i := range policyList.Items {
 			policy := &policyList.Items[i]
 
-			// Accept policies with wellKnownCACertificates: System or caCertificateRefs
-			hasWellKnown := policy.Spec.Validation.WellKnownCACertificates != nil &&
-				*policy.Spec.Validation.WellKnownCACertificates == gatewayv1.WellKnownCACertificatesSystem
-			hasCertRefs := len(policy.Spec.Validation.CACertificateRefs) > 0
-
-			if !hasWellKnown && !hasCertRefs {
-				r.Logger.Warn("BackendTLSPolicy has no CA certificate configuration, skipping",
-					"policy", fmt.Sprintf("%s/%s", policy.Namespace, policy.Name))
+			// Skip policies whose CA references cannot be resolved. The status path
+			// reports these as ResolvedRefs=False; enabling backend TLS anyway would
+			// break verification and 502 all traffic to the Service (M-7).
+			if resolved, reason, _ := validateBackendTLSCACerts(ctx, r.Client, policy); !resolved {
+				r.Logger.Warn("BackendTLSPolicy CA references unresolvable, skipping",
+					"policy", fmt.Sprintf("%s/%s", policy.Namespace, policy.Name),
+					"reason", reason)
 				continue
 			}
 
@@ -860,24 +882,83 @@ func (r *HTTPRouteReconciler) attachBackendTLS(ctx context.Context, collectedRou
 				if targetRef.Group != "" || targetRef.Kind != "Service" {
 					continue
 				}
-				key := ns + "/" + string(targetRef.Name)
-				policyMap[key] = policy
+				section := ""
+				if targetRef.SectionName != nil {
+					section = string(*targetRef.SectionName)
+				}
+				key := backendTLSKey{namespace: ns, service: string(targetRef.Name), section: section}
+				// GEP-713 precedence: keep the oldest / alphabetically-first policy
+				// for this scope so the data-plane winner matches the status winner (M-5).
+				if existing, ok := policyMap[key]; !ok || policyHasPrecedence(policy, existing) {
+					policyMap[key] = policy
+				}
 			}
 		}
 	}
 
-	// Attach TLS config to routes whose backends match a policy
+	// Attach TLS config to routes whose backends match a policy. A section-scoped
+	// policy (keyed by the route's Service port name) takes precedence over a
+	// section-less policy for the same Service.
+	svcPortNameCache := make(map[types.NamespacedName]map[int]string)
 	for i := range collectedRoutes {
 		cr := &collectedRoutes[i]
-		key := cr.Namespace + "/" + cr.Service
-		policy, ok := policyMap[key]
-		if !ok {
+
+		section := r.resolveServicePortName(ctx, cr, svcPortNameCache)
+
+		policy := (*gatewayv1.BackendTLSPolicy)(nil)
+		if section != "" {
+			policy = policyMap[backendTLSKey{namespace: cr.Namespace, service: cr.Service, section: section}]
+		}
+		if policy == nil {
+			policy = policyMap[backendTLSKey{namespace: cr.Namespace, service: cr.Service, section: ""}]
+		}
+		if policy == nil {
 			continue
 		}
 		cr.BackendTLS = &ghost.BackendTLS{
 			Hostname: string(policy.Spec.Validation.Hostname),
 		}
 	}
+}
+
+// resolveServicePortName returns the name of the Service port the collected route
+// targets. BackendTLSPolicy targetRef.SectionName is a Service *port name*, so this
+// is what section-scoped policies are matched against. Returns "" when the port is
+// unnamed or the Service cannot be resolved (in which case only section-less
+// policies apply). Results are cached per Service across routes.
+func (r *HTTPRouteReconciler) resolveServicePortName(ctx context.Context, route *ghost.Route, cache map[types.NamespacedName]map[int]string) string {
+	// A named targetPort is resolved upstream (buildServicePortMap) to the Service
+	// port name, which the collected route already carries verbatim.
+	if route.PortName != "" {
+		return route.PortName
+	}
+	if route.Service == "" {
+		return ""
+	}
+
+	nn := types.NamespacedName{Namespace: route.Namespace, Name: route.Service}
+	portToName, ok := cache[nn]
+	if !ok {
+		portToName = make(map[int]string)
+		var svc corev1.Service
+		if err := r.Get(ctx, nn, &svc); err == nil {
+			for _, sp := range svc.Spec.Ports {
+				// Map the resolved target port back to the Service port name. This
+				// mirrors buildServicePortMap: a numeric targetPort resolves to that
+				// port, otherwise the target defaults to the Service port itself.
+				resolved := int(sp.Port)
+				if sp.TargetPort.Type == intstr.Int && sp.TargetPort.IntVal != 0 {
+					resolved = int(sp.TargetPort.IntVal)
+				}
+				// Keep the first name for a given resolved port for determinism.
+				if _, exists := portToName[resolved]; !exists {
+					portToName[resolved] = sp.Name
+				}
+			}
+		}
+		cache[nn] = portToName
+	}
+	return portToName[route.Port]
 }
 
 // attachExternalProxies resolves routes whose backend Service is of type

--- a/internal/controller/infra_hash.go
+++ b/internal/controller/infra_hash.go
@@ -55,6 +55,11 @@ type InfrastructureConfig struct {
 	// HasBackendTLS indicates whether backend TLS (via BackendTLSPolicy) is configured.
 	// Changes to this trigger a pod restart to add/remove the CA cert volume and SSL_CERT_FILE env.
 	HasBackendTLS bool
+
+	// Resources are the container resource requests/limits from
+	// GatewayClassParameters.spec.resources. Editing them must roll the pods so
+	// the new requests/limits actually take effect, so they are part of the hash.
+	Resources *corev1.ResourceRequirements
 }
 
 // ComputeHash returns a deterministic SHA256 hash of the infrastructure configuration
@@ -127,6 +132,16 @@ func (c *InfrastructureConfig) ComputeHash() string {
 	if c.HasBackendTLS {
 		h.Write([]byte("backend-tls"))
 	}
+	h.Write([]byte{0}) // separator
+
+	// Include container resource requests/limits. JSON marshaling of the
+	// corev1 struct is deterministic (struct field order), and resource.Quantity
+	// marshals to its canonical string form.
+	if c.Resources != nil {
+		data, _ := json.Marshal(c.Resources)
+		h.Write(data)
+	}
+	h.Write([]byte{0}) // separator
 
 	return hex.EncodeToString(h.Sum(nil))
 }

--- a/internal/controller/infra_hash_test.go
+++ b/internal/controller/infra_hash_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	gatewayparamsv1alpha1 "github.com/varnish/gateway/api/v1alpha1"
 )
@@ -259,6 +260,58 @@ func TestInfrastructureConfig_SecretOrderDoesNotAffectHash(t *testing.T) {
 // The check is structural (via reflection) because behavioral verification
 // would require enumerating every possible Service-shape field; structural
 // absence of the fields is a stronger, simpler guard.
+// TestInfrastructureConfig_ResourcesAffectHash covers M-2: editing
+// spec.resources must change the infrastructure hash so the Deployment rolls
+// and pods pick up the new requests/limits.
+func TestInfrastructureConfig_ResourcesAffectHash(t *testing.T) {
+	base := InfrastructureConfig{GatewayImage: "img:v1"}
+	baseHash := base.ComputeHash()
+
+	withResources := InfrastructureConfig{
+		GatewayImage: "img:v1",
+		Resources: &corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("250m"),
+				corev1.ResourceMemory: resource.MustParse("512Mi"),
+			},
+		},
+	}
+	if withResources.ComputeHash() == baseHash {
+		t.Error("ComputeHash() did not change after adding Resources")
+	}
+
+	// Changing a limit must change the hash too.
+	changed := InfrastructureConfig{
+		GatewayImage: "img:v1",
+		Resources: &corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("250m"),
+				corev1.ResourceMemory: resource.MustParse("512Mi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("1Gi"),
+			},
+		},
+	}
+	if changed.ComputeHash() == withResources.ComputeHash() {
+		t.Error("ComputeHash() did not change after changing resource limits")
+	}
+
+	// Identical Resources must produce an identical hash (stability).
+	dup := InfrastructureConfig{
+		GatewayImage: "img:v1",
+		Resources: &corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("250m"),
+				corev1.ResourceMemory: resource.MustParse("512Mi"),
+			},
+		},
+	}
+	if dup.ComputeHash() != withResources.ComputeHash() {
+		t.Error("ComputeHash() not stable for identical Resources")
+	}
+}
+
 func TestInfraHash_ServiceConfigDoesNotAffectHash(t *testing.T) {
 	cfg := InfrastructureConfig{}
 	configType := reflect.TypeOf(cfg)

--- a/internal/controller/resources.go
+++ b/internal/controller/resources.go
@@ -32,7 +32,38 @@ const (
 
 	// Chaperone dashboard port (always enabled, access via port-forward)
 	chaperoneDashboardPort = 9000
+
+	// ghostReloadPort is the loopback-only HTTP listener used for ghost reloads.
+	ghostReloadPort = 1969
+
+	// chaperoneDebugPort is the loopback-only pprof/backend.list debug endpoint
+	// (chaperone DEBUG_ADDR default 127.0.0.1:6060).
+	chaperoneDebugPort = 6060
+
+	// varnishAdminPort is the varnishadm reverse-mode port the chaperone binds.
+	varnishAdminPort = 6082
 )
+
+// reservedContainerPorts are ports the chaperone/data-plane binds internally.
+// A Gateway listener on any of these would collide with an internal bind and
+// crash-loop the pod (the chaperone errgroup cancels everything on a bind
+// failure), so such listeners are rejected via a listener status condition
+// instead of being programmed. The value is a human-readable description used
+// in the rejection message.
+var reservedContainerPorts = map[int32]string{
+	ghostReloadPort:        "ghost reload loopback listener",
+	chaperoneDebugPort:     "chaperone pprof/debug endpoint",
+	varnishAdminPort:       "varnishadm admin port",
+	chaperoneHealthPort:    "chaperone health/metrics endpoint",
+	chaperoneDashboardPort: "chaperone dashboard endpoint",
+}
+
+// isReservedPort reports whether a Gateway listener port collides with an
+// internal data-plane bind and therefore cannot be programmed.
+func isReservedPort(port int32) bool {
+	_, ok := reservedContainerPorts[port]
+	return ok
+}
 
 // listenerSocketName returns the Varnish socket name for a Gateway listener.
 // Format: {proto}-{port}, e.g. "http-80", "https-443"
@@ -397,6 +428,13 @@ func (r *GatewayReconciler) buildGatewayContainer(gateway *gatewayv1.Gateway, cf
 			continue
 		}
 		seenPorts[port] = true
+		// Skip listener ports that collide with an internal data-plane bind.
+		// Programming them would crash-loop the pod; the reconciler surfaces a
+		// PortUnavailable listener condition for these instead (see
+		// setListenerStatusesForUpdate).
+		if isReservedPort(port) {
+			continue
+		}
 		proto := "http"
 		if l.Protocol == gatewayv1.HTTPSProtocolType || l.Protocol == gatewayv1.TLSProtocolType {
 			proto = "https"
@@ -411,7 +449,6 @@ func (r *GatewayReconciler) buildGatewayContainer(gateway *gatewayv1.Gateway, cf
 	// Build VARNISH_LISTEN value
 	// Always include a loopback-only HTTP listener for ghost reload.
 	// This avoids sending plain HTTP reload requests to HTTPS listeners.
-	const ghostReloadPort = 1969
 	var listenParts []string
 	listenParts = append(listenParts, fmt.Sprintf("ghost-reload=127.0.0.1:%d,http", ghostReloadPort))
 	for _, e := range entries {
@@ -629,6 +666,11 @@ func (r *GatewayReconciler) buildService(gateway *gatewayv1.Gateway, resolved Re
 			continue
 		}
 		seenPorts[port] = true
+		// Reserved ports are never programmed (see buildGatewayContainer), so
+		// don't expose a Service port for them either.
+		if isReservedPort(port) {
+			continue
+		}
 		ports = append(ports, corev1.ServicePort{
 			Name:       listenerSocketName(l),
 			Port:       port,

--- a/internal/controller/resources_test.go
+++ b/internal/controller/resources_test.go
@@ -1049,3 +1049,68 @@ func TestBuildLoggingSidecar_ExtraArgs(t *testing.T) {
 		t.Errorf("expected extra args in: %v", container.Args)
 	}
 }
+
+// TestIsReservedPort covers M-11: the internal data-plane bind ports must be
+// recognized as reserved.
+func TestIsReservedPort(t *testing.T) {
+	for _, p := range []int32{1969, 6060, 6082, 8081, 9000} {
+		if !isReservedPort(p) {
+			t.Errorf("port %d should be reserved", p)
+		}
+	}
+	for _, p := range []int32{80, 443, 8080, 3000} {
+		if isReservedPort(p) {
+			t.Errorf("port %d should not be reserved", p)
+		}
+	}
+}
+
+// TestBuildGatewayContainer_SkipsReservedPort covers M-11: a listener on a
+// reserved port must not be programmed into VARNISH_LISTEN or the container
+// ports (which would crash-loop the pod).
+func TestBuildGatewayContainer_SkipsReservedPort(t *testing.T) {
+	r := testReconcilerSimple()
+	gw := testGateway("my-gw", "default",
+		gatewayv1.Listener{Name: "ok", Port: 80, Protocol: gatewayv1.HTTPProtocolType},
+		gatewayv1.Listener{Name: "bad", Port: 8081, Protocol: gatewayv1.HTTPProtocolType},
+	)
+
+	container := r.buildGatewayContainer(gw, deploymentConfig{effectiveImage: "test:latest"})
+
+	var varnishListen string
+	for _, e := range container.Env {
+		if e.Name == "VARNISH_LISTEN" {
+			varnishListen = e.Value
+		}
+	}
+	if !strings.Contains(varnishListen, "http-80=:80,http") {
+		t.Errorf("VARNISH_LISTEN %q should program port 80", varnishListen)
+	}
+	if strings.Contains(varnishListen, ":8081") {
+		t.Errorf("VARNISH_LISTEN %q must not program reserved port 8081", varnishListen)
+	}
+	for _, p := range container.Ports {
+		if p.ContainerPort == 8081 && p.Name == "http-8081" {
+			t.Errorf("reserved listener port 8081 must not be exposed as a container port")
+		}
+	}
+}
+
+// TestBuildService_SkipsReservedPort covers M-11: reserved listener ports must
+// not be exposed as Service ports either.
+func TestBuildService_SkipsReservedPort(t *testing.T) {
+	r := testReconcilerSimple()
+	gw := testGateway("my-gw", "default",
+		gatewayv1.Listener{Name: "ok", Port: 80, Protocol: gatewayv1.HTTPProtocolType},
+		gatewayv1.Listener{Name: "bad", Port: 9000, Protocol: gatewayv1.HTTPProtocolType},
+	)
+
+	svc := r.buildService(gw, ResolvedServiceConfig{Type: corev1.ServiceTypeLoadBalancer, Annotations: map[string]string{}, Labels: map[string]string{}})
+
+	if len(svc.Spec.Ports) != 1 {
+		t.Fatalf("expected 1 service port (reserved port skipped), got %d", len(svc.Spec.Ports))
+	}
+	if svc.Spec.Ports[0].Port != 80 {
+		t.Errorf("expected port 80, got %d", svc.Spec.Ports[0].Port)
+	}
+}

--- a/internal/controller/varnishcachepolicy_controller.go
+++ b/internal/controller/varnishcachepolicy_controller.go
@@ -12,9 +12,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
@@ -38,18 +40,44 @@ func (r *VarnishCachePolicyReconciler) Reconcile(ctx context.Context, req ctrl.R
 	var vcp gatewayparamsv1alpha1.VarnishCachePolicy
 	if err := r.Get(ctx, req.NamespacedName, &vcp); err != nil {
 		if apierrors.IsNotFound(err) {
+			// The VCP was deleted. Its target is no longer knowable from here,
+			// so re-evaluate every sibling in the namespace: a policy that was
+			// previously Conflicted may now win (the winning policy could have
+			// been the one just deleted). Without this, the loser stays
+			// Conflicted until the next informer resync (~10h).
+			r.reevaluateSiblings(ctx, req.Namespace, "")
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, fmt.Errorf("r.Get(%s): %w", req.NamespacedName, err)
 	}
 
+	accepted, reason, message, requeueAfter, err := r.computeCondition(ctx, &vcp)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	r.setAccepted(&vcp, accepted, reason, message)
+	if statusErr := r.Status().Update(ctx, &vcp); statusErr != nil {
+		log.Error("failed to update VCP status", "error", statusErr)
+	}
+
+	// Whenever this VCP changes, re-evaluate its siblings so their
+	// conflict/winner status stays correct (e.g. this policy being created,
+	// retargeted, or newly winning demotes/promotes the others). Skip the VCP
+	// we just handled to avoid redundant work.
+	r.reevaluateSiblings(ctx, vcp.Namespace, vcp.Name)
+
+	log.Debug("VarnishCachePolicy reconciliation complete")
+	return ctrl.Result{RequeueAfter: requeueAfter}, nil
+}
+
+// computeCondition determines the Accepted condition for a VCP without mutating
+// or persisting it. It returns the accepted flag, condition reason and message,
+// a requeue delay (for transient target-not-found situations), and a non-nil
+// error only for unexpected API failures that warrant a controller retry.
+func (r *VarnishCachePolicyReconciler) computeCondition(ctx context.Context, vcp *gatewayparamsv1alpha1.VarnishCachePolicy) (bool, string, string, time.Duration, error) {
 	// Validate the VCP spec
-	if err := r.validateSpec(&vcp); err != nil {
-		r.setAccepted(&vcp, false, "Invalid", err.Error())
-		if statusErr := r.Status().Update(ctx, &vcp); statusErr != nil {
-			log.Error("failed to update VCP status", "error", statusErr)
-		}
-		return ctrl.Result{}, nil
+	if err := r.validateSpec(vcp); err != nil {
+		return false, "Invalid", err.Error(), 0, nil
 	}
 
 	// Check target exists
@@ -61,14 +89,11 @@ func (r *VarnishCachePolicyReconciler) Reconcile(ctx context.Context, req ctrl.R
 		var route gatewayv1.HTTPRoute
 		if err := r.Get(ctx, types.NamespacedName{Name: targetName, Namespace: vcp.Namespace}, &route); err != nil {
 			if apierrors.IsNotFound(err) {
-				r.setAccepted(&vcp, false, "TargetNotFound",
-					fmt.Sprintf("HTTPRoute %q not found in namespace %q", targetName, vcp.Namespace))
-				if statusErr := r.Status().Update(ctx, &vcp); statusErr != nil {
-					log.Error("failed to update VCP status", "error", statusErr)
-				}
-				return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+				return false, "TargetNotFound",
+					fmt.Sprintf("HTTPRoute %q not found in namespace %q", targetName, vcp.Namespace),
+					10 * time.Second, nil
 			}
-			return ctrl.Result{}, fmt.Errorf("r.Get(HTTPRoute %s): %w", targetName, err)
+			return false, "", "", 0, fmt.Errorf("r.Get(HTTPRoute %s): %w", targetName, err)
 		}
 
 		// If sectionName is set, validate it matches a named rule
@@ -82,12 +107,8 @@ func (r *VarnishCachePolicyReconciler) Reconcile(ctx context.Context, req ctrl.R
 				}
 			}
 			if !found {
-				r.setAccepted(&vcp, false, "TargetNotFound",
-					fmt.Sprintf("No rule named %q in HTTPRoute %q", sn, targetName))
-				if statusErr := r.Status().Update(ctx, &vcp); statusErr != nil {
-					log.Error("failed to update VCP status", "error", statusErr)
-				}
-				return ctrl.Result{}, nil
+				return false, "TargetNotFound",
+					fmt.Sprintf("No rule named %q in HTTPRoute %q", sn, targetName), 0, nil
 			}
 		}
 
@@ -95,42 +116,82 @@ func (r *VarnishCachePolicyReconciler) Reconcile(ctx context.Context, req ctrl.R
 		var gw gatewayv1.Gateway
 		if err := r.Get(ctx, types.NamespacedName{Name: targetName, Namespace: vcp.Namespace}, &gw); err != nil {
 			if apierrors.IsNotFound(err) {
-				r.setAccepted(&vcp, false, "TargetNotFound",
-					fmt.Sprintf("Gateway %q not found in namespace %q", targetName, vcp.Namespace))
-				if statusErr := r.Status().Update(ctx, &vcp); statusErr != nil {
-					log.Error("failed to update VCP status", "error", statusErr)
-				}
-				return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+				return false, "TargetNotFound",
+					fmt.Sprintf("Gateway %q not found in namespace %q", targetName, vcp.Namespace),
+					10 * time.Second, nil
 			}
-			return ctrl.Result{}, fmt.Errorf("r.Get(Gateway %s): %w", targetName, err)
+			return false, "", "", 0, fmt.Errorf("r.Get(Gateway %s): %w", targetName, err)
 		}
 
 	default:
-		r.setAccepted(&vcp, false, "Invalid",
-			fmt.Sprintf("Unsupported target kind %q, must be Gateway or HTTPRoute", targetKind))
-		if statusErr := r.Status().Update(ctx, &vcp); statusErr != nil {
-			log.Error("failed to update VCP status", "error", statusErr)
-		}
-		return ctrl.Result{}, nil
+		return false, "Invalid",
+			fmt.Sprintf("Unsupported target kind %q, must be Gateway or HTTPRoute", targetKind), 0, nil
 	}
 
 	// Check for conflicts (another VCP targeting the same route)
-	if conflict := r.checkConflict(ctx, &vcp); conflict != "" {
-		r.setAccepted(&vcp, false, "Conflicted", conflict)
-		if statusErr := r.Status().Update(ctx, &vcp); statusErr != nil {
-			log.Error("failed to update VCP status", "error", statusErr)
+	if conflict := r.checkConflict(ctx, vcp); conflict != "" {
+		return false, "Conflicted", conflict, 0, nil
+	}
+
+	return true, "Accepted", "Policy accepted", 0, nil
+}
+
+// reevaluateSiblings recomputes and persists the Accepted condition for other
+// VCPs in the namespace, updating only those whose condition actually changed.
+// It is called on every reconcile (including deletes) so that a policy which was
+// Conflicted is promoted as soon as the winning policy is deleted or retargeted,
+// rather than waiting for the informer resync. skipName, when non-empty, is the
+// VCP that was just handled by the primary reconcile and is left untouched.
+func (r *VarnishCachePolicyReconciler) reevaluateSiblings(ctx context.Context, namespace, skipName string) {
+	var vcpList gatewayparamsv1alpha1.VarnishCachePolicyList
+	if err := r.List(ctx, &vcpList, client.InNamespace(namespace)); err != nil {
+		r.Logger.Error("failed to list VCPs for sibling re-evaluation", "namespace", namespace, "error", err)
+		return
+	}
+
+	for i := range vcpList.Items {
+		sibling := &vcpList.Items[i]
+		if skipName != "" && sibling.Name == skipName {
+			continue
 		}
-		return ctrl.Result{}, nil
-	}
 
-	// VCP is valid - set Accepted
-	r.setAccepted(&vcp, true, "Accepted", "Policy accepted")
-	if statusErr := r.Status().Update(ctx, &vcp); statusErr != nil {
-		log.Error("failed to update VCP status", "error", statusErr)
-	}
+		accepted, reason, message, _, err := r.computeCondition(ctx, sibling)
+		if err != nil {
+			// Transient API error while evaluating a sibling; skip it. It will
+			// be reconciled on its own or on the next relevant event.
+			continue
+		}
+		if vcpConditionMatches(sibling, accepted, reason, message) {
+			continue
+		}
 
-	log.Debug("VarnishCachePolicy reconciliation complete")
-	return ctrl.Result{}, nil
+		r.setAccepted(sibling, accepted, reason, message)
+		if statusErr := r.Status().Update(ctx, sibling); statusErr != nil {
+			r.Logger.Error("failed to update sibling VCP status", "vcp", sibling.Name, "error", statusErr)
+		}
+	}
+}
+
+// vcpConditionMatches reports whether the VCP's current Accepted condition
+// already equals the given desired values, so an update can be skipped. Avoiding
+// no-op writes keeps reevaluateSiblings from churning status (and, with the
+// GenerationChangedPredicate, from re-triggering reconciles in a loop).
+func vcpConditionMatches(vcp *gatewayparamsv1alpha1.VarnishCachePolicy, accepted bool, reason, message string) bool {
+	want := metav1.ConditionFalse
+	if accepted {
+		want = metav1.ConditionTrue
+	}
+	for _, ancestor := range vcp.Status.Ancestors {
+		for _, cond := range ancestor.Conditions {
+			if cond.Type == "Accepted" {
+				return cond.Status == want &&
+					cond.Reason == reason &&
+					cond.Message == message &&
+					cond.ObservedGeneration == vcp.Generation
+			}
+		}
+	}
+	return false
 }
 
 // validateSpec checks the VCP spec for correctness.
@@ -303,7 +364,11 @@ func (r *VarnishCachePolicyReconciler) findVCPsForGateway(ctx context.Context, o
 func (r *VarnishCachePolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		WithOptions(controller.Options{RateLimiter: defaultRateLimiter()}).
-		For(&gatewayparamsv1alpha1.VarnishCachePolicy{}).
+		// GenerationChangedPredicate ignores status-only updates. This matters
+		// because reevaluateSiblings writes sibling status; without it, those
+		// writes (and our own status writes) would re-trigger reconciles in a
+		// loop. Spec changes (generation bump), creates, and deletes still fire.
+		For(&gatewayparamsv1alpha1.VarnishCachePolicy{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Watches(
 			&gatewayv1.HTTPRoute{},
 			handler.EnqueueRequestsFromMapFunc(r.findVCPsForHTTPRoute),
@@ -346,8 +411,18 @@ func ResolveCachePolicyForRoute(ctx context.Context, c client.Client, route *gat
 		targetKind := string(vcp.Spec.TargetRef.Kind)
 		targetName := string(vcp.Spec.TargetRef.Name)
 
+		// PolicyTargetReference has no namespace field: a VCP always targets a
+		// resource in its own namespace (Reconcile validates the target there).
+		// We list VCPs from both the route's and the gateway's namespaces, so we
+		// must match each VCP against the resource that lives in *its* namespace.
+		// Otherwise a same-named Gateway/HTTPRoute in another namespace (with
+		// cross-namespace route attachment) could silently pull in a foreign
+		// policy.
+		routeMatch := targetKind == "HTTPRoute" && targetName == route.Name && vcp.Namespace == route.Namespace
+		gatewayMatch := targetKind == "Gateway" && gateway != nil && targetName == gateway.Name && vcp.Namespace == gateway.Namespace
+
 		switch {
-		case targetKind == "HTTPRoute" && targetName == route.Name && vcp.Spec.TargetRef.SectionName != nil:
+		case routeMatch && vcp.Spec.TargetRef.SectionName != nil:
 			// Rule-level VCP
 			sn := string(*vcp.Spec.TargetRef.SectionName)
 			if ruleName != "" && sn == ruleName {
@@ -356,13 +431,13 @@ func ResolveCachePolicyForRoute(ctx context.Context, c client.Client, route *gat
 				}
 			}
 
-		case targetKind == "HTTPRoute" && targetName == route.Name && vcp.Spec.TargetRef.SectionName == nil:
+		case routeMatch && vcp.Spec.TargetRef.SectionName == nil:
 			// Route-level VCP
 			if routeVCP == nil || isOlder(vcp, routeVCP) {
 				routeVCP = vcp
 			}
 
-		case targetKind == "Gateway" && gateway != nil && targetName == gateway.Name:
+		case gatewayMatch:
 			// Gateway-level VCP
 			if gatewayVCP == nil || isOlder(vcp, gatewayVCP) {
 				gatewayVCP = vcp

--- a/internal/controller/varnishcachepolicy_controller_test.go
+++ b/internal/controller/varnishcachepolicy_controller_test.go
@@ -833,6 +833,137 @@ func TestReconcile_Conflict(t *testing.T) {
 	assertVCPCondition(t, &updated, metav1.ConditionTrue, "Accepted")
 }
 
+// M-12: a Conflicted loser must be re-evaluated (and promoted) when the winning
+// VCP is deleted, rather than staying Conflicted until the informer resync.
+func TestReconcile_ConflictHealedAfterWinnerDeleted(t *testing.T) {
+	scheme := newTestScheme()
+	route := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-route", Namespace: "default"},
+	}
+
+	now := metav1.Now()
+	winner := &gatewayparamsv1alpha1.VarnishCachePolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "older-vcp",
+			Namespace:         "default",
+			CreationTimestamp: metav1.NewTime(now.Add(-time.Minute)),
+		},
+		Spec: gatewayparamsv1alpha1.VarnishCachePolicySpec{
+			TargetRef:  vcpTargetRef("HTTPRoute", "my-route", nil),
+			DefaultTTL: durationPtr(60 * time.Second),
+		},
+	}
+	loser := &gatewayparamsv1alpha1.VarnishCachePolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "newer-vcp",
+			Namespace:         "default",
+			CreationTimestamp: now,
+		},
+		Spec: gatewayparamsv1alpha1.VarnishCachePolicySpec{
+			TargetRef: vcpTargetRef("HTTPRoute", "my-route", nil),
+			ForcedTTL: durationPtr(300 * time.Second),
+		},
+	}
+
+	r := newVCPTestReconciler(scheme, route, winner, loser)
+	ctx := context.Background()
+
+	// Establish the conflict: winner accepted, loser conflicted.
+	for _, name := range []string{"older-vcp", "newer-vcp"} {
+		if _, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: name, Namespace: "default"}}); err != nil {
+			t.Fatalf("reconcile %s: %v", name, err)
+		}
+	}
+
+	var updated gatewayparamsv1alpha1.VarnishCachePolicy
+	if err := r.Get(ctx, types.NamespacedName{Name: "newer-vcp", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("get loser: %v", err)
+	}
+	assertVCPCondition(t, &updated, metav1.ConditionFalse, "Conflicted")
+
+	// Delete the winner and reconcile its (now missing) key. The NotFound path
+	// must re-evaluate siblings so the loser becomes the winner.
+	if err := r.Delete(ctx, winner); err != nil {
+		t.Fatalf("delete winner: %v", err)
+	}
+	if _, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: "older-vcp", Namespace: "default"}}); err != nil {
+		t.Fatalf("reconcile deleted winner: %v", err)
+	}
+
+	if err := r.Get(ctx, types.NamespacedName{Name: "newer-vcp", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("get loser after deletion: %v", err)
+	}
+	assertVCPCondition(t, &updated, metav1.ConditionTrue, "Accepted")
+}
+
+// M-12: retargeting the winner to a different resource must also promote the
+// previously-Conflicted loser, exercised via the found (non-delete) path.
+func TestReconcile_ConflictHealedAfterWinnerRetargeted(t *testing.T) {
+	scheme := newTestScheme()
+	routeA := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "route-a", Namespace: "default"},
+	}
+	routeB := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "route-b", Namespace: "default"},
+	}
+
+	now := metav1.Now()
+	winner := &gatewayparamsv1alpha1.VarnishCachePolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "older-vcp",
+			Namespace:         "default",
+			CreationTimestamp: metav1.NewTime(now.Add(-time.Minute)),
+		},
+		Spec: gatewayparamsv1alpha1.VarnishCachePolicySpec{
+			TargetRef:  vcpTargetRef("HTTPRoute", "route-a", nil),
+			DefaultTTL: durationPtr(60 * time.Second),
+		},
+	}
+	loser := &gatewayparamsv1alpha1.VarnishCachePolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "newer-vcp",
+			Namespace:         "default",
+			CreationTimestamp: now,
+		},
+		Spec: gatewayparamsv1alpha1.VarnishCachePolicySpec{
+			TargetRef: vcpTargetRef("HTTPRoute", "route-a", nil),
+			ForcedTTL: durationPtr(300 * time.Second),
+		},
+	}
+
+	r := newVCPTestReconciler(scheme, routeA, routeB, winner, loser)
+	ctx := context.Background()
+
+	for _, name := range []string{"older-vcp", "newer-vcp"} {
+		if _, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: name, Namespace: "default"}}); err != nil {
+			t.Fatalf("reconcile %s: %v", name, err)
+		}
+	}
+
+	var updated gatewayparamsv1alpha1.VarnishCachePolicy
+	if err := r.Get(ctx, types.NamespacedName{Name: "newer-vcp", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("get loser: %v", err)
+	}
+	assertVCPCondition(t, &updated, metav1.ConditionFalse, "Conflicted")
+
+	// Retarget the winner to route-b; the loser now stands alone on route-a.
+	if err := r.Get(ctx, types.NamespacedName{Name: "older-vcp", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("get winner: %v", err)
+	}
+	updated.Spec.TargetRef = vcpTargetRef("HTTPRoute", "route-b", nil)
+	if err := r.Update(ctx, &updated); err != nil {
+		t.Fatalf("retarget winner: %v", err)
+	}
+	if _, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: "older-vcp", Namespace: "default"}}); err != nil {
+		t.Fatalf("reconcile retargeted winner: %v", err)
+	}
+
+	if err := r.Get(ctx, types.NamespacedName{Name: "newer-vcp", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("get loser after retarget: %v", err)
+	}
+	assertVCPCondition(t, &updated, metav1.ConditionTrue, "Accepted")
+}
+
 func TestReconcile_NoConflict_DifferentTargets(t *testing.T) {
 	scheme := newTestScheme()
 	route1 := &gatewayv1.HTTPRoute{
@@ -1103,6 +1234,104 @@ func TestResolveCachePolicyForRoute(t *testing.T) {
 		cp := ResolveCachePolicyForRoute(context.Background(), c, route, nil, "")
 		if cp == nil {
 			t.Fatal("expected policy, got nil")
+		}
+	})
+}
+
+// M-13: VCPs must only match resources in their own namespace. With same-named
+// Gateways/HTTPRoutes across namespaces and cross-namespace route attachment, a
+// policy intended for one namespace must not leak into another.
+func TestResolveCachePolicyForRoute_CrossNamespace(t *testing.T) {
+	scheme := newTestScheme()
+
+	makeAcceptedVCP := func(name, namespace string, spec gatewayparamsv1alpha1.VarnishCachePolicySpec) *gatewayparamsv1alpha1.VarnishCachePolicy {
+		return &gatewayparamsv1alpha1.VarnishCachePolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              name,
+				Namespace:         namespace,
+				CreationTimestamp: metav1.Now(),
+			},
+			Spec: spec,
+			Status: gatewayparamsv1alpha1.VarnishCachePolicyStatus{
+				Ancestors: []gatewayparamsv1alpha1.VarnishCachePolicyAncestorStatus{
+					{
+						ControllerName: ControllerName,
+						Conditions: []metav1.Condition{
+							{Type: "Accepted", Status: metav1.ConditionTrue},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	// Route lives in team-a; the Gateway it attaches to lives in platform.
+	route := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "gw", Namespace: "team-a"},
+	}
+	gateway := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "gw", Namespace: "platform"},
+	}
+
+	t.Run("gateway-level VCP in route namespace does not leak to foreign gateway", func(t *testing.T) {
+		// VCP in team-a targeting a Gateway named "gw" — that means team-a/gw,
+		// NOT the platform/gw the route actually attaches to.
+		foreign := makeAcceptedVCP("foreign-gw-vcp", "team-a", gatewayparamsv1alpha1.VarnishCachePolicySpec{
+			TargetRef:  vcpTargetRef("Gateway", "gw", nil),
+			DefaultTTL: durationPtr(120 * time.Second),
+		})
+
+		c := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(foreign).Build()
+		cp := ResolveCachePolicyForRoute(context.Background(), c, route, gateway, "")
+		if cp != nil {
+			t.Fatal("expected nil: gateway VCP from a different namespace must not apply")
+		}
+	})
+
+	t.Run("gateway-level VCP in gateway namespace applies", func(t *testing.T) {
+		legit := makeAcceptedVCP("gw-vcp", "platform", gatewayparamsv1alpha1.VarnishCachePolicySpec{
+			TargetRef:  vcpTargetRef("Gateway", "gw", nil),
+			DefaultTTL: durationPtr(90 * time.Second),
+		})
+
+		c := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(legit).Build()
+		cp := ResolveCachePolicyForRoute(context.Background(), c, route, gateway, "")
+		if cp == nil {
+			t.Fatal("expected policy from gateway-namespace VCP")
+		}
+		if cp.DefaultTTLSeconds == nil || *cp.DefaultTTLSeconds != 90 {
+			t.Errorf("DefaultTTLSeconds = %v, want 90", cp.DefaultTTLSeconds)
+		}
+	})
+
+	t.Run("route-level VCP in gateway namespace does not leak to foreign route", func(t *testing.T) {
+		// A route named "gw" also exists conceptually in platform; a VCP there
+		// targeting HTTPRoute "gw" must not apply to team-a/gw.
+		foreign := makeAcceptedVCP("foreign-route-vcp", "platform", gatewayparamsv1alpha1.VarnishCachePolicySpec{
+			TargetRef:  vcpTargetRef("HTTPRoute", "gw", nil),
+			DefaultTTL: durationPtr(200 * time.Second),
+		})
+
+		c := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(foreign).Build()
+		cp := ResolveCachePolicyForRoute(context.Background(), c, route, gateway, "")
+		if cp != nil {
+			t.Fatal("expected nil: route VCP from a different namespace must not apply")
+		}
+	})
+
+	t.Run("route-level VCP in route namespace applies", func(t *testing.T) {
+		legit := makeAcceptedVCP("route-vcp", "team-a", gatewayparamsv1alpha1.VarnishCachePolicySpec{
+			TargetRef: vcpTargetRef("HTTPRoute", "gw", nil),
+			ForcedTTL: durationPtr(45 * time.Second),
+		})
+
+		c := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(legit).Build()
+		cp := ResolveCachePolicyForRoute(context.Background(), c, route, gateway, "")
+		if cp == nil {
+			t.Fatal("expected policy from route-namespace VCP")
+		}
+		if cp.ForcedTTLSeconds == nil || *cp.ForcedTTLSeconds != 45 {
+			t.Errorf("ForcedTTLSeconds = %v, want 45", cp.ForcedTTLSeconds)
 		}
 	})
 }

--- a/internal/ghost/generator.go
+++ b/internal/ghost/generator.go
@@ -114,11 +114,16 @@ func mergeRoutesByMatchCriteria(routes []Route, endpoints ServiceEndpoints) []Ro
 		filters     string // JSON serialization of Filters
 		listeners   string // sorted, comma-joined
 		cachePolicy string // JSON serialization of CachePolicy
-		backendTLS  string // TLS hostname (routes with different TLS must not merge)
 		priority    int
 		ruleIndex   int
 	}
 
+	// NOTE: BackendTLS is intentionally NOT part of the merge key. Each BackendGroup
+	// carries its own BackendTLS (see routeToBackendGroup), so backends with and
+	// without a BackendTLSPolicy in the same rule must merge into ONE route with
+	// multiple weighted groups. Keying on BackendTLS would split them into two
+	// routes with identical match criteria; ghost returns the FIRST matching route,
+	// so the weighted split would silently collapse (and output order is nondeterministic).
 	grouped := make(map[routeKey][]Route)
 	for _, route := range routes {
 		key := routeKey{
@@ -129,7 +134,6 @@ func mergeRoutesByMatchCriteria(routes []Route, endpoints ServiceEndpoints) []Ro
 			filters:     serializeFilters(route.Filters),
 			listeners:   serializeListeners(route.Listeners),
 			cachePolicy: serializeCachePolicy(route.CachePolicy),
-			backendTLS:  serializeBackendTLS(route.BackendTLS),
 			priority:    route.Priority,
 			ruleIndex:   route.RuleIndex,
 		}
@@ -223,15 +227,6 @@ func serializeCachePolicy(cp *CachePolicy) string {
 		return ""
 	}
 	data, _ := json.Marshal(cp)
-	return string(data)
-}
-
-// serializeBackendTLS converts BackendTLS to string for grouping.
-func serializeBackendTLS(tls *BackendTLS) string {
-	if tls == nil {
-		return ""
-	}
-	data, _ := json.Marshal(tls)
 	return string(data)
 }
 

--- a/internal/ghost/generator_test.go
+++ b/internal/ghost/generator_test.go
@@ -696,9 +696,12 @@ func TestBackendTLSPropagation(t *testing.T) {
 	}
 }
 
-func TestBackendTLSPreventsMerging(t *testing.T) {
-	// Two routes with identical match criteria but different TLS configs
-	// should NOT be merged into one route
+func TestBackendTLSMergesIntoWeightedGroups(t *testing.T) {
+	// M-10: Two backends in the same rule with identical match criteria — one with
+	// a BackendTLSPolicy, one without — must merge into ONE route carrying two
+	// weighted backend groups. Each group keeps its own BackendTLS. BackendTLS must
+	// NOT be part of the merge key, otherwise the weighted split silently collapses
+	// (ghost returns the first matching route) and output order is nondeterministic.
 	routingConfig := &RoutingConfig{
 		Version: 2,
 		VHosts: map[string]VHostRouting{
@@ -709,7 +712,7 @@ func TestBackendTLSPreventsMerging(t *testing.T) {
 						Service:    "tls-service",
 						Namespace:  "default",
 						Port:       8443,
-						Weight:     80,
+						Weight:     90,
 						Priority:   100,
 						BackendTLS: &BackendTLS{Hostname: "internal.example.com"},
 					},
@@ -718,7 +721,7 @@ func TestBackendTLSPreventsMerging(t *testing.T) {
 						Service:   "plain-service",
 						Namespace: "default",
 						Port:      8080,
-						Weight:    20,
+						Weight:    10,
 						Priority:  100,
 					},
 				},
@@ -734,8 +737,40 @@ func TestBackendTLSPreventsMerging(t *testing.T) {
 	config := Generate(routingConfig, endpoints)
 	vhost := config.VHosts["api.example.com"]
 
-	// Routes with different TLS configs must remain separate
-	if len(vhost.Routes) != 2 {
-		t.Fatalf("expected 2 separate routes (TLS prevents merging), got %d", len(vhost.Routes))
+	// Backends with identical match criteria must merge into a single route.
+	if len(vhost.Routes) != 1 {
+		t.Fatalf("expected 1 merged route, got %d", len(vhost.Routes))
+	}
+
+	route := vhost.Routes[0]
+	if len(route.BackendGroups) != 2 {
+		t.Fatalf("expected 2 weighted backend groups, got %d", len(route.BackendGroups))
+	}
+
+	// Verify both weights are preserved and TLS is attached to the correct group.
+	var tlsGroups, plainGroups int
+	weights := map[int]bool{}
+	for _, g := range route.BackendGroups {
+		weights[g.Weight] = true
+		if g.BackendTLS != nil {
+			tlsGroups++
+			if g.BackendTLS.Hostname != "internal.example.com" {
+				t.Errorf("unexpected TLS hostname: %s", g.BackendTLS.Hostname)
+			}
+			if g.Weight != 90 {
+				t.Errorf("TLS group expected weight 90, got %d", g.Weight)
+			}
+		} else {
+			plainGroups++
+			if g.Weight != 10 {
+				t.Errorf("plain group expected weight 10, got %d", g.Weight)
+			}
+		}
+	}
+	if tlsGroups != 1 || plainGroups != 1 {
+		t.Errorf("expected 1 TLS group and 1 plain group, got %d/%d", tlsGroups, plainGroups)
+	}
+	if !weights[90] || !weights[10] {
+		t.Errorf("expected weights {90,10}, got %v", weights)
 	}
 }

--- a/internal/invalidation/watcher.go
+++ b/internal/invalidation/watcher.go
@@ -13,10 +13,12 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
@@ -25,6 +27,43 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 )
+
+// hostnameRE matches an RFC 1123 hostname (DNS name). It deliberately excludes
+// whitespace, quotes and the '&' character so that a hostname can never break
+// out of the Varnish ban expression it is concatenated into (see M-21 and the
+// BAN handler in internal/vcl/preamble.vcl).
+var hostnameRE = regexp.MustCompile(`^([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$`)
+
+// validateInvalidationSpec validates the untrusted hostname and paths from a
+// VarnishCacheInvalidation CR before any request is sent to Varnish.
+//
+// The hostname is set verbatim as the Host header and, via the ban-lurker
+// headers, concatenated into a Varnish ban expression. The paths become the
+// request URL, which for BAN is used as a regex inside the same expression.
+// Since std.ban() takes a single string with no escaping mechanism, strict
+// input validation here is the primary defense against ban-expression
+// injection: a hostname or path containing whitespace, quotes or '&' could
+// otherwise inject additional ban conditions and flush unrelated objects.
+func validateInvalidationSpec(hostname string, paths []string) error {
+	if hostname == "" {
+		return fmt.Errorf("spec.hostname is required")
+	}
+	if len(hostname) > 253 || !hostnameRE.MatchString(hostname) {
+		return fmt.Errorf("spec.hostname %q is not a valid RFC 1123 hostname", hostname)
+	}
+	if len(paths) == 0 {
+		return fmt.Errorf("spec.paths must contain at least one path")
+	}
+	for _, p := range paths {
+		if !strings.HasPrefix(p, "/") {
+			return fmt.Errorf("spec.paths entry %q must start with '/'", p)
+		}
+		if strings.ContainsAny(p, " \t\r\n\"") {
+			return fmt.Errorf("spec.paths entry %q must not contain whitespace or quotes", p)
+		}
+	}
+	return nil
+}
 
 var varnishCacheInvalidationGVR = schema.GroupVersionResource{
 	Group:    "gateway.varnish-software.com",
@@ -191,10 +230,39 @@ func (w *Watcher) handleInvalidation(ctx context.Context, obj *unstructured.Unst
 		return
 	}
 
+	// M-14: enforce same-namespace authorization. The CR must live in the same
+	// namespace as the target gateway. The only cluster-level authorization for
+	// a VarnishCacheInvalidation is "can create the CR somewhere"; without this
+	// check any author could set spec.gatewayRef.namespace to an unrelated
+	// gateway and purge/ban (or `type: Ban` with `.*` flush) its entire cache.
+	// The chaperone has no controller-runtime client to evaluate a
+	// ReferenceGrant, so cross-namespace refs are rejected outright — matching
+	// how the rest of the operator treats cross-namespace references (a
+	// ReferenceGrant would be the follow-up to relax this).
+	if ns != gwNS {
+		msg := fmt.Sprintf("cross-namespace gatewayRef not permitted: VarnishCacheInvalidation in namespace %q targets gateway in namespace %q (create the invalidation in %q)", ns, gwNS, gwNS)
+		w.logger.Warn("rejecting cross-namespace cache invalidation", "name", name, "namespace", ns, "gatewayNamespace", gwNS)
+		if w.updateStatus(ctx, ns, name, false, msg, nil) {
+			w.markProcessed(uid)
+		}
+		return
+	}
+
 	// Extract spec fields
 	invType, _, _ := unstructured.NestedString(obj.Object, "spec", "type")
 	hostname, _, _ := unstructured.NestedString(obj.Object, "spec", "hostname")
 	paths, _, _ := unstructured.NestedStringSlice(obj.Object, "spec", "paths")
+
+	// M-21: validate untrusted hostname/paths BEFORE issuing any request. An
+	// invalid spec is a terminal Failed result, not a transient error.
+	if err := validateInvalidationSpec(hostname, paths); err != nil {
+		msg := fmt.Sprintf("invalid cache invalidation spec: %v", err)
+		w.logger.Warn("rejecting invalid cache invalidation", "name", name, "namespace", ns, "error", err)
+		if w.updateStatus(ctx, ns, name, false, msg, nil) {
+			w.markProcessed(uid)
+		}
+		return
+	}
 
 	w.logger.Info("processing cache invalidation",
 		"name", name,
@@ -248,13 +316,23 @@ func (w *Watcher) handleInvalidation(ctx context.Context, obj *unstructured.Unst
 		)
 	}
 
-	// Mark as processed locally
+	// Write per-pod result and compute aggregate phase. Mark the invalidation
+	// as processed locally ONLY after the status write succeeds (M-20). If the
+	// status update fails (transient API error, exhausted conflict retries) we
+	// leave it unprocessed so a later watch event or re-list retries it — the
+	// podAlreadyReported guard and the idempotency of purge/ban make
+	// reprocessing safe, and this prevents a CR from being wedged in
+	// Pending/InProgress forever (where operator GC never reaps it).
+	if w.updateStatus(ctx, ns, name, success, message, pathResults) {
+		w.markProcessed(uid)
+	}
+}
+
+// markProcessed records that this pod has finished processing the given UID.
+func (w *Watcher) markProcessed(uid string) {
 	w.mu.Lock()
 	w.processed[uid] = struct{}{}
 	w.mu.Unlock()
-
-	// Write per-pod result and compute aggregate phase
-	w.updateStatus(ctx, ns, name, success, message, pathResults)
 }
 
 // podAlreadyReported checks if this pod already has a result in status.podResults.
@@ -292,8 +370,11 @@ func (w *Watcher) executePurge(ctx context.Context, hostname, path string) error
 		resp.Body.Close()
 	}()
 
-	// Varnish returns 200 on successful purge (both cache hit and miss)
-	if resp.StatusCode != http.StatusOK {
+	// Varnish's return(purge) synthesizes 200 on a cache hit and 404 ("Not in
+	// cache") on a miss. Purge is an idempotent delete: purging a URL that is
+	// not cached still leaves the cache in the desired state (object absent),
+	// so 404 is a success, not a failure (M-19). Any other status is an error.
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNotFound {
 		return fmt.Errorf("PURGE returned HTTP %d", resp.StatusCode)
 	}
 
@@ -330,19 +411,27 @@ func (w *Watcher) executeBan(ctx context.Context, hostname, path string) error {
 // updateStatus appends this pod's result to status.podResults and computes the
 // aggregate phase. Uses optimistic concurrency (resourceVersion) to handle
 // concurrent updates from multiple pods.
-func (w *Watcher) updateStatus(ctx context.Context, namespace, name string, success bool, message string, pathResults []any) {
+//
+// It returns true when the status was durably recorded (either this pod's
+// result was written, or this pod was already recorded), and false on any
+// failure to persist. Callers use the return value to decide whether to mark
+// the invalidation processed (M-20): a false return means "retry later".
+func (w *Watcher) updateStatus(ctx context.Context, namespace, name string, success bool, message string, pathResults []any) bool {
 	if w.dynClient == nil {
+		// No status backend (only happens in tests/standalone). There is
+		// nothing to persist, so treat the work as done to avoid reprocessing.
 		w.logger.Warn("no dynamic client, skipping status update", "name", name)
-		return
+		return true
 	}
 	// Retry loop for conflict resolution (multiple pods updating concurrently)
-	for attempt := 0; attempt < 5; attempt++ {
+	const maxAttempts = 5
+	for attempt := 0; attempt < maxAttempts; attempt++ {
 		// Get the latest version
 		current, err := w.dynClient.Resource(varnishCacheInvalidationGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			w.logger.Error("failed to get VarnishCacheInvalidation for status update",
 				"name", name, "error", err)
-			return
+			return false
 		}
 
 		// Build this pod's result
@@ -362,7 +451,7 @@ func (w *Watcher) updateStatus(ctx context.Context, namespace, name string, succ
 		for _, r := range existingResults {
 			if m, ok := r.(map[string]any); ok {
 				if pn, _, _ := unstructured.NestedString(m, "podName"); pn == w.podName {
-					return // already reported
+					return true // already reported — durably recorded
 				}
 			}
 		}
@@ -383,19 +472,25 @@ func (w *Watcher) updateStatus(ctx context.Context, namespace, name string, succ
 
 		if err := unstructured.SetNestedField(current.Object, status, "status"); err != nil {
 			w.logger.Error("failed to set status fields", "error", err)
-			return
+			return false
 		}
 
 		_, err = w.dynClient.Resource(varnishCacheInvalidationGVR).Namespace(namespace).UpdateStatus(
 			ctx, current, metav1.UpdateOptions{})
 		if err != nil {
-			if strings.Contains(err.Error(), "the object has been modified") {
+			if apierrors.IsConflict(err) {
 				w.logger.Debug("status update conflict, retrying", "attempt", attempt+1)
+				// Bounded backoff before re-reading and retrying.
+				select {
+				case <-ctx.Done():
+					return false
+				case <-time.After(time.Duration(attempt+1) * 50 * time.Millisecond):
+				}
 				continue
 			}
 			w.logger.Error("failed to update VarnishCacheInvalidation status",
 				"name", name, "error", err)
-			return
+			return false
 		}
 
 		w.logger.Info("cache invalidation status updated",
@@ -404,10 +499,11 @@ func (w *Watcher) updateStatus(ctx context.Context, namespace, name string, succ
 			"phase", phase,
 			"podResults", len(existingResults),
 		)
-		return
+		return true
 	}
 
 	w.logger.Error("failed to update status after max retries", "name", name)
+	return false
 }
 
 // computePhase determines the aggregate phase based on podResults and expected pod count.

--- a/internal/invalidation/watcher_test.go
+++ b/internal/invalidation/watcher_test.go
@@ -970,6 +970,255 @@ func TestProcessExisting_ProcessesMatchingGatewayOnly(t *testing.T) {
 	}
 }
 
+// --- M-14: cross-namespace authorization ---
+
+func TestHandleInvalidation_RejectsCrossNamespaceGatewayRef(t *testing.T) {
+	requestReceived := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestReceived = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	addr := strings.TrimPrefix(srv.URL, "http://")
+
+	// CR lives in "other-ns" but targets a gateway in "default" (our namespace).
+	// Even though the gatewayRef name/namespace match this chaperone's identity,
+	// the CR is not in the gateway's namespace, so it must be rejected.
+	obj := makeVarnishCacheInvalidation("inv-xns", "other-ns", "uid-xns", "purge", "example.com", []string{"/foo"}, "my-gw", "default")
+	dynClient := newMemoryDynamicClient(obj)
+	w := newTestWatcherWithK8s(addr, "my-gw", "default", "pod-0")
+	w.dynClient = dynClient
+
+	w.handleInvalidation(context.Background(), obj)
+
+	if requestReceived {
+		t.Error("expected no HTTP request for cross-namespace gatewayRef, but one was sent")
+	}
+
+	got := getStoredInvalidation(t, dynClient, "other-ns", "inv-xns")
+	status := requireNestedMap(t, got.Object, "status")
+	if phase := status["phase"]; phase != "Failed" {
+		t.Fatalf("phase = %v, want Failed", phase)
+	}
+	podResults := requireNestedSlice(t, got.Object, "status", "podResults")
+	if len(podResults) != 1 {
+		t.Fatalf("podResults length = %d, want 1", len(podResults))
+	}
+	result := podResults[0].(map[string]any)
+	if result["success"] != false {
+		t.Errorf("success = %v, want false", result["success"])
+	}
+	msg, _ := result["message"].(string)
+	if !strings.Contains(msg, "cross-namespace") {
+		t.Errorf("message = %q, want it to mention cross-namespace", msg)
+	}
+}
+
+// --- M-21: hostname/path validation ---
+
+func TestValidateInvalidationSpec(t *testing.T) {
+	tests := []struct {
+		name     string
+		hostname string
+		paths    []string
+		wantErr  bool
+	}{
+		{name: "valid host and path", hostname: "api.example.com", paths: []string{"/v1/users"}, wantErr: false},
+		{name: "valid ban regex path", hostname: "example.com", paths: []string{"/api/.*"}, wantErr: false},
+		{name: "empty hostname", hostname: "", paths: []string{"/foo"}, wantErr: true},
+		{name: "hostname with quote", hostname: `x" && obj.status == 200`, paths: []string{"/foo"}, wantErr: true},
+		{name: "hostname with space", hostname: "bad host", paths: []string{"/foo"}, wantErr: true},
+		{name: "hostname with ampersand", hostname: "a&&b", paths: []string{"/foo"}, wantErr: true},
+		{name: "no paths", hostname: "example.com", paths: nil, wantErr: true},
+		{name: "path missing leading slash", hostname: "example.com", paths: []string{"foo"}, wantErr: true},
+		{name: "path with space injection", hostname: "example.com", paths: []string{"/foo && obj.status == 200"}, wantErr: true},
+		{name: "path with quote", hostname: "example.com", paths: []string{`/foo"`}, wantErr: true},
+		{name: "one bad path among good", hostname: "example.com", paths: []string{"/ok", "bad"}, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateInvalidationSpec(tt.hostname, tt.paths)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateInvalidationSpec(%q, %v) err = %v, wantErr %v", tt.hostname, tt.paths, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestHandleInvalidation_RejectsInvalidHostname(t *testing.T) {
+	requestReceived := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestReceived = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	addr := strings.TrimPrefix(srv.URL, "http://")
+	obj := makeVarnishCacheInvalidation("inv-badhost", "default", "uid-badhost", "ban",
+		`evil" && obj.http.x-cache-url ~ .`, []string{"/foo"}, "my-gw", "default")
+	dynClient := newMemoryDynamicClient(obj)
+	w := newTestWatcherWithK8s(addr, "my-gw", "default", "pod-0")
+	w.dynClient = dynClient
+
+	w.handleInvalidation(context.Background(), obj)
+
+	if requestReceived {
+		t.Error("expected no request for invalid hostname, but one was sent")
+	}
+	got := getStoredInvalidation(t, dynClient, "default", "inv-badhost")
+	status := requireNestedMap(t, got.Object, "status")
+	if phase := status["phase"]; phase != "Failed" {
+		t.Fatalf("phase = %v, want Failed", phase)
+	}
+	result := requireNestedSlice(t, got.Object, "status", "podResults")[0].(map[string]any)
+	msg, _ := result["message"].(string)
+	if !strings.Contains(msg, "invalid cache invalidation spec") {
+		t.Errorf("message = %q, want it to mention invalid spec", msg)
+	}
+}
+
+func TestHandleInvalidation_RejectsInvalidPath(t *testing.T) {
+	requestReceived := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestReceived = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	addr := strings.TrimPrefix(srv.URL, "http://")
+	obj := makeVarnishCacheInvalidation("inv-badpath", "default", "uid-badpath", "purge",
+		"example.com", []string{"no-leading-slash"}, "my-gw", "default")
+	dynClient := newMemoryDynamicClient(obj)
+	w := newTestWatcherWithK8s(addr, "my-gw", "default", "pod-0")
+	w.dynClient = dynClient
+
+	w.handleInvalidation(context.Background(), obj)
+
+	if requestReceived {
+		t.Error("expected no request for invalid path, but one was sent")
+	}
+	got := getStoredInvalidation(t, dynClient, "default", "inv-badpath")
+	status := requireNestedMap(t, got.Object, "status")
+	if phase := status["phase"]; phase != "Failed" {
+		t.Fatalf("phase = %v, want Failed", phase)
+	}
+}
+
+// --- M-19: PURGE of an uncached URL (404) is a success ---
+
+func TestExecutePurge_NotInCacheIsSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Varnish returns 404 "Not in cache" when purging a URL that is not cached.
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	addr := strings.TrimPrefix(srv.URL, "http://")
+	w := newTestWatcher(addr, "my-gw", "default", "pod-0")
+
+	if err := w.executePurge(context.Background(), "example.com", "/never-cached"); err != nil {
+		t.Fatalf("executePurge should treat 404 as success, got error: %v", err)
+	}
+}
+
+func TestHandleInvalidation_PurgeMissReportsSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound) // cache miss
+	}))
+	defer srv.Close()
+
+	addr := strings.TrimPrefix(srv.URL, "http://")
+	obj := makeVarnishCacheInvalidation("inv-miss", "default", "uid-miss", "purge", "example.com",
+		[]string{"/not-cached"}, "my-gw", "default")
+	dynClient := newMemoryDynamicClient(obj)
+	w := newTestWatcherWithK8s(addr, "my-gw", "default", "pod-0")
+	w.dynClient = dynClient
+
+	w.handleInvalidation(context.Background(), obj)
+
+	got := getStoredInvalidation(t, dynClient, "default", "inv-miss")
+	status := requireNestedMap(t, got.Object, "status")
+	if phase := status["phase"]; phase != "Complete" {
+		t.Fatalf("phase = %v, want Complete (404 purge miss is a success)", phase)
+	}
+}
+
+// --- M-20: processed only recorded after a successful status write ---
+
+func TestHandleInvalidation_NotProcessedWhenStatusUpdateFails(t *testing.T) {
+	var requestCount int
+	var mu sync.Mutex
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requestCount++
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	addr := strings.TrimPrefix(srv.URL, "http://")
+	obj := makeVarnishCacheInvalidation("inv-statusfail", "default", "uid-statusfail", "purge", "example.com",
+		[]string{"/foo"}, "my-gw", "default")
+	dynClient := newMemoryDynamicClient(obj)
+	dynClient.updateStatusErr = fmt.Errorf("apiserver unavailable")
+	w := newTestWatcherWithK8s(addr, "my-gw", "default", "pod-0")
+	w.dynClient = dynClient
+
+	// First call: purge sent, but status write fails -> must NOT be processed.
+	w.handleInvalidation(context.Background(), obj)
+	w.mu.Lock()
+	_, processed := w.processed["uid-statusfail"]
+	w.mu.Unlock()
+	if processed {
+		t.Fatal("invalidation must not be marked processed when the status update fails")
+	}
+
+	// Second call: reprocessing must happen (idempotent purge re-sent).
+	w.handleInvalidation(context.Background(), obj)
+	mu.Lock()
+	count := requestCount
+	mu.Unlock()
+	if count != 2 {
+		t.Fatalf("expected reprocessing to re-send purge, request count = %d, want 2", count)
+	}
+
+	// Once the status write succeeds, it is marked processed and not retried again.
+	dynClient.mu.Lock()
+	dynClient.updateStatusErr = nil
+	dynClient.mu.Unlock()
+	w.handleInvalidation(context.Background(), obj)
+	w.mu.Lock()
+	_, processed = w.processed["uid-statusfail"]
+	w.mu.Unlock()
+	if !processed {
+		t.Fatal("invalidation should be marked processed after a successful status write")
+	}
+}
+
+func TestHandleInvalidation_MarkedProcessedAfterSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	addr := strings.TrimPrefix(srv.URL, "http://")
+	obj := makeVarnishCacheInvalidation("inv-ok-proc", "default", "uid-ok-proc", "purge", "example.com",
+		[]string{"/foo"}, "my-gw", "default")
+	dynClient := newMemoryDynamicClient(obj)
+	w := newTestWatcherWithK8s(addr, "my-gw", "default", "pod-0")
+	w.dynClient = dynClient
+
+	w.handleInvalidation(context.Background(), obj)
+
+	w.mu.Lock()
+	_, processed := w.processed["uid-ok-proc"]
+	w.mu.Unlock()
+	if !processed {
+		t.Fatal("invalidation should be marked processed after successful status write")
+	}
+}
+
 // makeVarnishCacheInvalidation is a helper to build an unstructured VarnishCacheInvalidation object.
 func makeVarnishCacheInvalidation(name, ns, uid, invType, hostname string, paths []string, gwName, gwNS string) *unstructured.Unstructured {
 	// Convert []string to []any for unstructured
@@ -1036,6 +1285,7 @@ type memoryDynamicClient struct {
 	mu                sync.Mutex
 	objects           map[string]*unstructured.Unstructured
 	updateStatusCount int
+	updateStatusErr   error // when set, UpdateStatus fails with this error
 }
 
 var _ dynamic.Interface = (*memoryDynamicClient)(nil)
@@ -1080,9 +1330,12 @@ func (r *memoryDynamicResource) UpdateStatus(ctx context.Context, obj *unstructu
 	if err := r.checkResource(); err != nil {
 		return nil, err
 	}
-	key := objectKey(r.namespace, obj.GetName())
 	r.client.mu.Lock()
 	defer r.client.mu.Unlock()
+	if r.client.updateStatusErr != nil {
+		return nil, r.client.updateStatusErr
+	}
+	key := objectKey(r.namespace, obj.GetName())
 	if _, ok := r.client.objects[key]; !ok {
 		return nil, fmt.Errorf("%s not found", key)
 	}

--- a/internal/tls/reloader.go
+++ b/internal/tls/reloader.go
@@ -70,20 +70,43 @@ func (r *Reloader) FatalError() <-chan error {
 	return r.fatalErrCh
 }
 
-// LoadAll reads all .pem files from the cert directory and loads them into Varnish.
-// Should be called once during startup before the Varnish child starts.
-func (r *Reloader) LoadAll() error {
-	entries, err := os.ReadDir(r.certDir)
-	if err != nil {
-		return fmt.Errorf("os.ReadDir(%s): %w", r.certDir, err)
+// rollbackAfterTransportError issues a tls.cert.rollback after a transport
+// (RPC-level) error from tls.cert.load or tls.cert.commit, unless the error
+// is comms-class. Comms errors are ambiguous about server-side state — the
+// command may have actually landed before the response was lost — so issuing
+// a rollback then would either no-op or, worse, undo a transaction that
+// actually committed. op is used only to label the log message (e.g.
+// "load", "commit"). Shared by LoadAll and reloadAllCerts so the rollback
+// policy cannot diverge between the startup and hot-reload paths (M-23).
+func (r *Reloader) rollbackAfterTransportError(err error, op string) {
+	if isCommsError(err) {
+		r.logger.Warn("TLS cert " + op + " comms-error; skipping rollback to avoid state divergence")
+		return
 	}
+	if _, rbErr := r.varnishadm.TLSCertRollback(); rbErr != nil {
+		r.logger.Error("TLS cert rollback failed after "+op+" error", "error", rbErr)
+	}
+}
 
+// rollbackAfterStatusError issues a tls.cert.rollback after a status-level
+// rejection (the RPC succeeded but varnishd reported failure, e.g. a
+// malformed cert). The server-side transaction is in a known state here, so
+// rollback is always safe — no comms-error branching needed.
+func (r *Reloader) rollbackAfterStatusError(op string) {
+	if _, rbErr := r.varnishadm.TLSCertRollback(); rbErr != nil {
+		r.logger.Error("TLS cert rollback failed after "+op+" error", "error", rbErr)
+	}
+}
+
+// loadCertFiles loads each .pem file in entries into Varnish via
+// tls.cert.load, staging them into whatever transaction is currently open
+// (LoadAll starts none explicitly; reloadAllCerts opens one via discards).
+// On error it applies the same comms-aware rollback policy used for commit
+// errors and returns the count loaded so far alongside the error.
+func (r *Reloader) loadCertFiles(entries []os.DirEntry) (int, error) {
 	var loaded int
 	for _, entry := range entries {
-		if entry.IsDir() {
-			continue
-		}
-		if !strings.HasSuffix(entry.Name(), ".pem") {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".pem") {
 			continue
 		}
 
@@ -94,28 +117,44 @@ func (r *Reloader) LoadAll() error {
 
 		resp, err := r.varnishadm.TLSCertLoad(name, path, "")
 		if err != nil {
-			// Comms-class error: we don't know if the load landed
-			// server-side. Skip the rollback (which would either no-op or
-			// undo unrelated state on a reconnected connection); the next
-			// reload cycle will reconcile.
-			if !isCommsError(err) {
-				if _, rbErr := r.varnishadm.TLSCertRollback(); rbErr != nil {
-					r.logger.Error("TLS cert rollback failed after load error", "error", rbErr)
-				}
-			} else {
-				r.logger.Warn("TLS cert load comms-error; skipping rollback to avoid state divergence", "name", name)
-			}
-			return fmt.Errorf("varnishadm.TLSCertLoad(%s, %s): %w", name, path, err)
+			r.rollbackAfterTransportError(err, "load")
+			return loaded, fmt.Errorf("varnishadm.TLSCertLoad(%s, %s): %w", name, path, err)
 		}
 		if err := resp.CheckOK("tls.cert.load %s failed", name); err != nil {
-			// Status-level rejection (e.g. malformed cert): the server-side
-			// transaction is in a known state, so rollback is safe.
-			if _, rbErr := r.varnishadm.TLSCertRollback(); rbErr != nil {
-				r.logger.Error("TLS cert rollback failed after load error", "error", rbErr)
-			}
-			return err
+			r.rollbackAfterStatusError("load")
+			return loaded, err
 		}
 		loaded++
+	}
+	return loaded, nil
+}
+
+// commitCerts issues tls.cert.commit for the currently open transaction,
+// applying the same comms-aware rollback policy as loadCertFiles.
+func (r *Reloader) commitCerts() error {
+	resp, err := r.varnishadm.TLSCertCommit()
+	if err != nil {
+		r.rollbackAfterTransportError(err, "commit")
+		return fmt.Errorf("varnishadm.TLSCertCommit: %w", err)
+	}
+	if err := resp.CheckOK("tls.cert.commit failed"); err != nil {
+		r.rollbackAfterStatusError("commit")
+		return err
+	}
+	return nil
+}
+
+// LoadAll reads all .pem files from the cert directory and loads them into Varnish.
+// Should be called once during startup before the Varnish child starts.
+func (r *Reloader) LoadAll() error {
+	entries, err := os.ReadDir(r.certDir)
+	if err != nil {
+		return fmt.Errorf("os.ReadDir(%s): %w", r.certDir, err)
+	}
+
+	loaded, err := r.loadCertFiles(entries)
+	if err != nil {
+		return err
 	}
 
 	if loaded == 0 {
@@ -123,26 +162,7 @@ func (r *Reloader) LoadAll() error {
 		return nil
 	}
 
-	// Commit all loaded certificates
-	resp, err := r.varnishadm.TLSCertCommit()
-	if err != nil {
-		// Comms error on commit is ambiguous: the commit may have actually
-		// landed server-side. Issuing rollback now would either no-op or,
-		// worse, undo unrelated staged state on the next-connected handler.
-		// Bail out instead and let the next reload cycle reconcile.
-		if !isCommsError(err) {
-			if _, rbErr := r.varnishadm.TLSCertRollback(); rbErr != nil {
-				r.logger.Error("TLS cert rollback failed after commit error", "error", rbErr)
-			}
-		} else {
-			r.logger.Warn("TLS cert commit comms-error; skipping rollback (commit may have landed server-side)")
-		}
-		return fmt.Errorf("varnishadm.TLSCertCommit: %w", err)
-	}
-	if err := resp.CheckOK("tls.cert.commit failed"); err != nil {
-		if _, rbErr := r.varnishadm.TLSCertRollback(); rbErr != nil {
-			r.logger.Error("TLS cert rollback failed after commit error", "error", rbErr)
-		}
+	if err := r.commitCerts(); err != nil {
 		return err
 	}
 
@@ -180,31 +200,9 @@ func (r *Reloader) reloadAllCerts() error {
 		}
 	}
 
-	var loaded int
-	for _, entry := range entries {
-		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".pem") {
-			continue
-		}
-
-		name := strings.TrimSuffix(entry.Name(), ".pem")
-		path := filepath.Join(r.certDir, entry.Name())
-
-		r.logger.Debug("loading TLS certificate", "name", name, "path", path)
-
-		resp, err := r.varnishadm.TLSCertLoad(name, path, "")
-		if err != nil {
-			if _, rbErr := r.varnishadm.TLSCertRollback(); rbErr != nil {
-				r.logger.Error("TLS cert rollback failed after load error", "error", rbErr)
-			}
-			return fmt.Errorf("varnishadm.TLSCertLoad(%s, %s): %w", name, path, err)
-		}
-		if err := resp.CheckOK("tls.cert.load %s failed", name); err != nil {
-			if _, rbErr := r.varnishadm.TLSCertRollback(); rbErr != nil {
-				r.logger.Error("TLS cert rollback failed after load error", "error", rbErr)
-			}
-			return err
-		}
-		loaded++
+	loaded, err := r.loadCertFiles(entries)
+	if err != nil {
+		return err
 	}
 
 	// If nothing was discarded and nothing loaded, no transaction was started
@@ -213,18 +211,12 @@ func (r *Reloader) reloadAllCerts() error {
 		return nil
 	}
 
-	// Commit the transaction
-	resp, err := r.varnishadm.TLSCertCommit()
-	if err != nil {
-		if _, rbErr := r.varnishadm.TLSCertRollback(); rbErr != nil {
-			r.logger.Error("TLS cert rollback failed after commit error", "error", rbErr)
-		}
-		return fmt.Errorf("varnishadm.TLSCertCommit: %w", err)
-	}
-	if err := resp.CheckOK("tls.cert.commit failed"); err != nil {
-		if _, rbErr := r.varnishadm.TLSCertRollback(); rbErr != nil {
-			r.logger.Error("TLS cert rollback failed after commit error", "error", rbErr)
-		}
+	// Commit the transaction. Uses the same isCommsError-aware rollback
+	// policy as LoadAll (via commitCerts/rollbackAfterTransportError) — a
+	// comms error here is ambiguous about whether the commit landed
+	// server-side, so unconditionally rolling back would risk undoing a
+	// transaction that actually committed (M-23).
+	if err := r.commitCerts(); err != nil {
 		return err
 	}
 

--- a/internal/tls/reloader_test.go
+++ b/internal/tls/reloader_test.go
@@ -2,6 +2,7 @@ package tls
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -13,6 +14,30 @@ import (
 	"github.com/fsnotify/fsnotify"
 	"github.com/varnish/gateway/internal/varnishadm"
 )
+
+// commsErrorVarnishadm wraps MockVarnishadm to force a specific TLS cert
+// operation to fail with a comms-class error (as classified by
+// isCommsError), for testing the M-23 rollback-skip policy. All other
+// methods delegate to the embedded mock.
+type commsErrorVarnishadm struct {
+	*varnishadm.MockVarnishadm
+	failCommit bool
+	failLoad   bool
+}
+
+func (f *commsErrorVarnishadm) TLSCertCommit() (varnishadm.VarnishResponse, error) {
+	if f.failCommit {
+		return varnishadm.VarnishResponse{}, fmt.Errorf("varnishadm communication failed: connection reset")
+	}
+	return f.MockVarnishadm.TLSCertCommit()
+}
+
+func (f *commsErrorVarnishadm) TLSCertLoad(name, certFile, privateKeyFile string) (varnishadm.VarnishResponse, error) {
+	if f.failLoad {
+		return varnishadm.VarnishResponse{}, fmt.Errorf("varnishadm connection lost: EOF")
+	}
+	return f.MockVarnishadm.TLSCertLoad(name, certFile, privateKeyFile)
+}
 
 // TestShouldReload is the deterministic, platform-independent guard for the
 // H-9 fix: fsnotify events on the Kubernetes atomic-writer "..data" symlink
@@ -741,5 +766,95 @@ func TestReloadAllCerts_RemoveAllCerts(t *testing.T) {
 	state := mock.GetTLSState()
 	if len(state) != 0 {
 		t.Errorf("Expected 0 committed certs, got %d", len(state))
+	}
+}
+
+// TestReloadAllCerts_CommitCommsError_SkipsRollback guards M-23: a comms-class
+// error on tls.cert.commit is ambiguous about whether the commit actually
+// landed server-side, so reloadAllCerts must NOT issue tls.cert.rollback in
+// that case (unlike a status-level rejection, where the transaction state is
+// known and rollback is safe). This must match LoadAll's existing policy.
+func TestReloadAllCerts_CommitCommsError_SkipsRollback(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "new.pem"), []byte("cert"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	base := varnishadm.NewMock(0, "", slog.Default())
+	mock := &commsErrorVarnishadm{MockVarnishadm: base, failCommit: true}
+	r := New(mock, dir, slog.Default())
+
+	err := r.reloadAllCerts()
+	if err == nil {
+		t.Fatal("reloadAllCerts() expected error on commit comms failure, got nil")
+	}
+
+	// tls.cert.commit itself is intercepted by commsErrorVarnishadm before it
+	// reaches the underlying mock's Exec (that's how the comms error is
+	// injected), so it deliberately does not appear in the recorded history.
+	// What matters here is that no rollback follows it.
+	history := base.GetCallHistory()
+	for _, cmd := range history {
+		if cmd == "tls.cert.rollback" {
+			t.Errorf("reloadAllCerts() should NOT roll back after a comms-class commit error; history: %v", history)
+		}
+	}
+}
+
+// TestReloadAllCerts_LoadCommsError_SkipsRollback guards M-23 for the
+// tls.cert.load path: a comms-class error there is likewise ambiguous about
+// server-side state, so no rollback should be issued.
+func TestReloadAllCerts_LoadCommsError_SkipsRollback(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "bad.pem"), []byte("cert"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	base := varnishadm.NewMock(0, "", slog.Default())
+	mock := &commsErrorVarnishadm{MockVarnishadm: base, failLoad: true}
+	r := New(mock, dir, slog.Default())
+
+	err := r.reloadAllCerts()
+	if err == nil {
+		t.Fatal("reloadAllCerts() expected error on load comms failure, got nil")
+	}
+
+	history := base.GetCallHistory()
+	for _, cmd := range history {
+		if cmd == "tls.cert.rollback" {
+			t.Errorf("reloadAllCerts() should NOT roll back after a comms-class load error; history: %v", history)
+		}
+	}
+}
+
+// TestReloadAllCerts_CommitStatusError_StillRollsBack is the control case:
+// a status-level rejection (not comms-class) means the transaction is in a
+// known state server-side, so rollback must still happen. This guards
+// against a fix that accidentally suppresses rollback unconditionally.
+func TestReloadAllCerts_CommitStatusError_StillRollsBack(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "new.pem"), []byte("cert"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	mock := varnishadm.NewMock(0, "", slog.Default())
+	mock.SetResponse("tls.cert.commit", varnishadm.NewVarnishResponse(300, "commit rejected"))
+
+	r := New(mock, dir, slog.Default())
+
+	err := r.reloadAllCerts()
+	if err == nil {
+		t.Fatal("reloadAllCerts() expected error on commit status rejection, got nil")
+	}
+
+	history := mock.GetCallHistory()
+	var foundRollback bool
+	for _, cmd := range history {
+		if cmd == "tls.cert.rollback" {
+			foundRollback = true
+		}
+	}
+	if !foundRollback {
+		t.Errorf("reloadAllCerts() should roll back after a non-comms commit rejection; history: %v", history)
 	}
 }

--- a/internal/vcl/generator.go
+++ b/internal/vcl/generator.go
@@ -171,12 +171,16 @@ func CollectHTTPRouteBackends(routes []gatewayv1.HTTPRoute, gateway *gatewayv1.G
 						filters = extractFilters(rule.Filters)
 					}
 
+					// A rule with no matches is semantically identical to a rule with
+					// matches:[{path:{type:PathPrefix,value:"/"}}]. PathPrefix "/" matches
+					// all paths and carries no specificity, so we normalize it to a nil
+					// pathMatch (priority 0) — exactly as the explicit-"/" branch does below.
+					// Assigning a concrete PathPrefix "/" here would inflate the priority to
+					// 10100, making a no-match rule outrank an equivalent explicit "/" rule.
+					var pathMatch *ghost.PathMatch
+
 					// Handle filter-only routes with no backends (e.g., redirects with no matches)
 					if len(rule.BackendRefs) == 0 && filters != nil {
-						pathMatch := &ghost.PathMatch{
-							Type:  ghost.PathMatchPathPrefix,
-							Value: "/",
-						}
 						collectedRoutes = append(collectedRoutes, ghost.Route{
 							Hostname:  hostname,
 							PathMatch: pathMatch,
@@ -198,10 +202,6 @@ func CollectHTTPRouteBackends(routes []gatewayv1.HTTPRoute, gateway *gatewayv1.G
 
 					// If all backends were filtered, create a route with no backend (ghost returns 500)
 					if len(validNoMatchBackends) == 0 && len(rule.BackendRefs) > 0 {
-						pathMatch := &ghost.PathMatch{
-							Type:  ghost.PathMatchPathPrefix,
-							Value: "/",
-						}
 						collectedRoutes = append(collectedRoutes, ghost.Route{
 							Hostname:  hostname,
 							PathMatch: pathMatch,
@@ -241,12 +241,6 @@ func CollectHTTPRouteBackends(routes []gatewayv1.HTTPRoute, gateway *gatewayv1.G
 						weight := 1 // Gateway API default when unspecified
 						if backend.Weight != nil {
 							weight = int(*backend.Weight)
-						}
-
-						// Default route with PathPrefix "/"
-						pathMatch := &ghost.PathMatch{
-							Type:  ghost.PathMatchPathPrefix,
-							Value: "/",
 						}
 
 						collectedRoutes = append(collectedRoutes, ghost.Route{
@@ -399,7 +393,7 @@ func CollectHTTPRouteBackends(routes []gatewayv1.HTTPRoute, gateway *gatewayv1.G
 								}
 							}
 
-							weight := 100
+							weight := 1 // Gateway API default when unspecified
 							if backend.Weight != nil {
 								weight = int(*backend.Weight)
 							}
@@ -592,6 +586,15 @@ func convertRequestRedirectFilter(f *gatewayv1.HTTPRequestRedirectFilter) *ghost
 	return result
 }
 
+// noSuchListenerSocket is a sentinel socket name that is never bound by Varnish.
+// It is emitted as a route's sole listener when a route's parentRef filter is
+// PRESENT but resolves to no existing listener. Because ghost filters routes by
+// the live local.socket() name and this sentinel can never equal a real socket,
+// the route matches on NO listener — preserving the user's restriction intent.
+// Emitting an empty slice instead would be dropped by omitempty, and ghost treats
+// an absent listeners list as "match all listeners" — the exact opposite.
+const noSuchListenerSocket = "__no_such_listener__"
+
 // socketNameForListener returns the Varnish socket name for a Gateway listener.
 // Format: {proto}-{port}, e.g. "http-80", "https-443"
 func socketNameForListener(listener *gatewayv1.Listener) string {
@@ -661,6 +664,14 @@ func listenersForRoute(route *gatewayv1.HTTPRoute, gateway *gatewayv1.Gateway) [
 
 	if !hasFilter {
 		return nil
+	}
+
+	// A filter is present but resolved to no existing listener (e.g. every
+	// parentRef names a sectionName/port that the gateway does not expose).
+	// The route must match NOTHING rather than everything — emit a sentinel
+	// socket that ghost can never match on.
+	if len(socketSet) == 0 {
+		return []string{noSuchListenerSocket}
 	}
 
 	// If the route covers ALL listeners of the gateway, return nil (no filtering needed)

--- a/internal/vcl/generator_test.go
+++ b/internal/vcl/generator_test.go
@@ -751,14 +751,15 @@ func TestCollectHTTPRouteBackends_NoMatches(t *testing.T) {
 		t.Fatalf("expected 1 route, got %d", len(collectedRoutes))
 	}
 
-	if collectedRoutes[0].PathMatch == nil {
-		t.Fatal("expected path match to be set")
+	// M-9: a rule with no matches is equivalent to matches:[{path:PathPrefix "/"}],
+	// which carries no specificity. It must be normalized to a nil PathMatch with
+	// priority 0 — identical to the explicit-"/" handling — so it does not outrank
+	// an equivalent explicit "/" route.
+	if collectedRoutes[0].PathMatch != nil {
+		t.Errorf("expected nil path match for no-match rule, got %+v", collectedRoutes[0].PathMatch)
 	}
-	if collectedRoutes[0].PathMatch.Type != ghost.PathMatchPathPrefix {
-		t.Errorf("expected path match type PathPrefix, got %v", collectedRoutes[0].PathMatch.Type)
-	}
-	if collectedRoutes[0].PathMatch.Value != "/" {
-		t.Errorf("expected path match value /, got %s", collectedRoutes[0].PathMatch.Value)
+	if collectedRoutes[0].Priority != 0 {
+		t.Errorf("expected priority 0 for no-match rule, got %d", collectedRoutes[0].Priority)
 	}
 }
 
@@ -822,7 +823,8 @@ func TestCollectHTTPRouteBackends_PortMapResolution(t *testing.T) {
 		if r.PathMatch != nil && r.PathMatch.Value == "/api" {
 			apiRoute = r
 		}
-		if r.PathMatch != nil && r.PathMatch.Value == "/" {
+		// The no-match (default) rule now yields a nil PathMatch (M-9).
+		if r.PathMatch == nil {
 			defaultRoute = r
 		}
 	}
@@ -1106,6 +1108,23 @@ func TestListenersForRoute_PortFilter(t *testing.T) {
 			},
 			want: nil,
 		},
+		{
+			// M-24: filter present but resolves to no existing listener. Must match
+			// NOTHING (sentinel), not everything. Emitting nil here would be dropped
+			// by omitempty and ghost would treat the route as "all listeners".
+			name: "sectionName resolves to nothing = match-nothing sentinel",
+			parentRefs: []gatewayv1.ParentReference{
+				{Name: "gw", SectionName: ptr(gatewayv1.SectionName("no-such-listener"))},
+			},
+			want: []string{noSuchListenerSocket},
+		},
+		{
+			name: "port resolves to nothing = match-nothing sentinel",
+			parentRefs: []gatewayv1.ParentReference{
+				{Name: "gw", Port: ptr(gatewayv1.PortNumber(9999))},
+			},
+			want: []string{noSuchListenerSocket},
+		},
 	}
 
 	for _, tc := range tests {
@@ -1134,5 +1153,131 @@ func TestListenersForRoute_PortFilter(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestCollectHTTPRouteBackends_DefaultWeightIsOne verifies M-8: a backendRef with
+// no explicit weight defaults to 1 (Gateway API spec) in the matches branch too
+// (not 100). Mixing explicit and implicit weights previously inverted intended
+// splits (e.g. {a,weight:10},{b} yielded 10:100 instead of 10:1).
+func TestCollectHTTPRouteBackends_DefaultWeightIsOne(t *testing.T) {
+	prefixType := gatewayv1.PathMatchPathPrefix
+	routes := []gatewayv1.HTTPRoute{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "route-1", Namespace: "default"},
+			Spec: gatewayv1.HTTPRouteSpec{
+				Hostnames: []gatewayv1.Hostname{"api.example.com"},
+				Rules: []gatewayv1.HTTPRouteRule{
+					{
+						Matches: []gatewayv1.HTTPRouteMatch{
+							{Path: &gatewayv1.HTTPPathMatch{Type: &prefixType, Value: ptr("/split")}},
+						},
+						BackendRefs: []gatewayv1.HTTPBackendRef{
+							{BackendRef: gatewayv1.BackendRef{
+								BackendObjectReference: gatewayv1.BackendObjectReference{Name: "svc-a", Port: ptr(gatewayv1.PortNumber(80))},
+								Weight:                 ptr(int32(10)),
+							}},
+							{BackendRef: gatewayv1.BackendRef{
+								// no weight -> should default to 1
+								BackendObjectReference: gatewayv1.BackendObjectReference{Name: "svc-b", Port: ptr(gatewayv1.PortNumber(80))},
+							}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	collected := CollectHTTPRouteBackends(routes, nil, "default", nil, nil, nil)
+
+	var wA, wB int
+	found := 0
+	for _, r := range collected {
+		switch r.Service {
+		case "svc-a":
+			wA = r.Weight
+			found++
+		case "svc-b":
+			wB = r.Weight
+			found++
+		}
+	}
+	if found != 2 {
+		t.Fatalf("expected svc-a and svc-b routes, found %d", found)
+	}
+	if wA != 10 {
+		t.Errorf("svc-a weight = %d, want 10", wA)
+	}
+	if wB != 1 {
+		t.Errorf("svc-b weight = %d, want 1 (Gateway API default), not 100", wB)
+	}
+}
+
+// TestNoMatchRuleMatchesExplicitSlashPriority verifies M-9: a rule with no matches
+// must produce the same priority (0) as an equivalent rule with an explicit
+// PathPrefix "/" match, since both match all paths with no specificity.
+func TestNoMatchRuleMatchesExplicitSlashPriority(t *testing.T) {
+	prefixType := gatewayv1.PathMatchPathPrefix
+	routes := []gatewayv1.HTTPRoute{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "route-1", Namespace: "default"},
+			Spec: gatewayv1.HTTPRouteSpec{
+				Hostnames: []gatewayv1.Hostname{"api.example.com"},
+				Rules: []gatewayv1.HTTPRouteRule{
+					{
+						// no-match rule
+						BackendRefs: []gatewayv1.HTTPBackendRef{
+							{BackendRef: gatewayv1.BackendRef{
+								BackendObjectReference: gatewayv1.BackendObjectReference{Name: "nomatch-svc", Port: ptr(gatewayv1.PortNumber(80))},
+							}},
+						},
+					},
+					{
+						// explicit PathPrefix "/"
+						Matches: []gatewayv1.HTTPRouteMatch{
+							{Path: &gatewayv1.HTTPPathMatch{Type: &prefixType, Value: ptr("/")}},
+						},
+						BackendRefs: []gatewayv1.HTTPBackendRef{
+							{BackendRef: gatewayv1.BackendRef{
+								BackendObjectReference: gatewayv1.BackendObjectReference{Name: "explicit-svc", Port: ptr(gatewayv1.PortNumber(80))},
+							}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	collected := CollectHTTPRouteBackends(routes, nil, "default", nil, nil, nil)
+
+	var noMatchPrio, explicitPrio int
+	foundNoMatch, foundExplicit := false, false
+	for _, r := range collected {
+		switch r.Service {
+		case "nomatch-svc":
+			noMatchPrio = r.Priority
+			foundNoMatch = true
+			if r.PathMatch != nil {
+				t.Errorf("no-match rule should have nil PathMatch, got %+v", r.PathMatch)
+			}
+		case "explicit-svc":
+			explicitPrio = r.Priority
+			foundExplicit = true
+			if r.PathMatch != nil {
+				t.Errorf("explicit-/ rule should have nil PathMatch, got %+v", r.PathMatch)
+			}
+		}
+	}
+	if !foundNoMatch || !foundExplicit {
+		t.Fatalf("expected both routes; noMatch=%v explicit=%v", foundNoMatch, foundExplicit)
+	}
+	if noMatchPrio != 0 {
+		t.Errorf("no-match rule priority = %d, want 0", noMatchPrio)
+	}
+	if explicitPrio != 0 {
+		t.Errorf("explicit-/ rule priority = %d, want 0", explicitPrio)
+	}
+	if noMatchPrio != explicitPrio {
+		t.Errorf("no-match (%d) and explicit-/ (%d) priorities must be equal", noMatchPrio, explicitPrio)
 	}
 }

--- a/internal/vcl/preamble.vcl
+++ b/internal/vcl/preamble.vcl
@@ -56,6 +56,18 @@ sub vcl_recv {
     # Chaperone sends: BAN /pattern.* HTTP/1.1 \n Host: example.com
     # Uses ban lurker friendly expressions (obj.http.*) for background cleanup.
     # Only handles localhost requests; non-localhost BAN falls through to user VCL.
+    #
+    # std.ban() takes a single string with no escaping mechanism, so req.http.host
+    # and req.url are concatenated raw into the ban expression below. This is safe
+    # ONLY because the request originates from the chaperone, which validates the
+    # VarnishCacheInvalidation spec before issuing the BAN (see
+    # validateInvalidationSpec in internal/invalidation/watcher.go): the hostname
+    # must be an RFC 1123 hostname (no whitespace, quotes or '&') and every path
+    # must start with '/' and contain no whitespace or quotes. Those constraints
+    # make it impossible for either value to inject additional ban conditions
+    # (e.g. a trailing "&& ..." that would flush unrelated vhosts). The BAN method
+    # is further restricted to localhost above. Do not relax this validation
+    # without revisiting the injection surface here.
     if (req.method == "BAN" && client.ip ~ localhost) {
         if (std.ban("obj.http.x-cache-host == " + req.http.host +
                      " && obj.http.x-cache-url ~ " + req.url)) {

--- a/internal/vcl/reloader.go
+++ b/internal/vcl/reloader.go
@@ -151,13 +151,17 @@ func (r *Reloader) handleConfigMapUpdate(cm *corev1.ConfigMap) {
 
 	r.lastVCLMux.Lock()
 
-	// Deduplicate via ResourceVersion
+	// Deduplicate via ResourceVersion. lastConfigMapRV is only advanced after
+	// a successful reload (see below) — never unconditionally on entry. If it
+	// were recorded here regardless of outcome, a transient ReloadInline
+	// failure would strand it at this RV, and this dedup check would then
+	// SKIP every subsequent resync/re-delivery of the same object (same RV),
+	// leaving Varnish running stale VCL indefinitely with no retry (M-22).
 	if cm.ResourceVersion != "" && cm.ResourceVersion == r.lastConfigMapRV {
 		r.lastVCLMux.Unlock()
 		r.logger.Debug("skipping duplicate ConfigMap update", "resourceVersion", cm.ResourceVersion)
 		return
 	}
-	r.lastConfigMapRV = cm.ResourceVersion
 
 	// Extract main.vcl
 	newVCL, ok := cm.Data["main.vcl"]
@@ -179,10 +183,12 @@ func (r *Reloader) handleConfigMapUpdate(cm *corev1.ConfigMap) {
 	r.logger.Info("main.vcl changed, triggering VCL reload",
 		"resourceVersion", cm.ResourceVersion)
 
-	// Trigger varnishadm reload with inline VCL. Only record the content as
-	// "applied" on success — otherwise the next ConfigMap event with the
-	// same content would be dedup-skipped and Varnish would stay on the old
-	// VCL while we believe the new one is active.
+	// Trigger varnishadm reload with inline VCL. Only record the content and
+	// ResourceVersion as "applied" on success — otherwise the next
+	// ConfigMap event with the same content/RV would be dedup-skipped and
+	// Varnish would stay on the old VCL while we believe the new one is
+	// active. On failure both markers are deliberately left untouched so the
+	// next resync of this same object retries the reload.
 	if err := r.ReloadInline(newVCL); err != nil {
 		r.logger.Error("VCL reload failed - keeping previous VCL", "error", err)
 		dashboard.PublishVCLReloadFail(r.dashBus, err)
@@ -190,6 +196,7 @@ func (r *Reloader) handleConfigMapUpdate(cm *corev1.ConfigMap) {
 	}
 	r.lastVCLMux.Lock()
 	r.lastVCL = newVCL
+	r.lastConfigMapRV = cm.ResourceVersion
 	r.lastVCLMux.Unlock()
 }
 

--- a/internal/vcl/reloader_test.go
+++ b/internal/vcl/reloader_test.go
@@ -412,6 +412,21 @@ func (f *failingVarnishadm) VCLInline(name, vcl string) (varnishadm.VarnishRespo
 	return varnishadm.NewVarnishResponse(varnishadm.ClisSyntax, "VCL compilation failed: syntax error"), nil
 }
 
+// flakyVarnishadm wraps MockVarnishadm so VCLInline can be toggled to fail
+// on demand, letting tests simulate a transient reload failure followed by a
+// successful retry of the same ConfigMap object.
+type flakyVarnishadm struct {
+	*varnishadm.MockVarnishadm
+	fail bool
+}
+
+func (f *flakyVarnishadm) VCLInline(name, vcl string) (varnishadm.VarnishResponse, error) {
+	if f.fail {
+		return varnishadm.NewVarnishResponse(varnishadm.ClisSyntax, "VCL compilation failed: injected failure"), nil
+	}
+	return f.MockVarnishadm.VCLInline(name, vcl)
+}
+
 func TestVCLReloadFailure_NonFatal(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	baseMock := varnishadm.NewMock(6082, "secret", logger)
@@ -447,5 +462,86 @@ func TestVCLReloadFailure_NonFatal(t *testing.T) {
 		// good: reloader survived the failure
 	case <-time.After(500 * time.Millisecond):
 		t.Error("handleConfigMapUpdate blocked after VCL compilation failure")
+	}
+}
+
+// TestHandleConfigMapUpdate_RetriesAfterReloadFailure guards M-22: a
+// transient ReloadInline failure must not strand lastConfigMapRV at the
+// failed delivery's ResourceVersion, because the RV-dedup check runs before
+// the content check — if the RV were recorded regardless of outcome, every
+// subsequent resync/re-delivery of the same object (same RV) would be
+// skipped, leaving Varnish running stale VCL indefinitely with no retry.
+func TestHandleConfigMapUpdate_RetriesAfterReloadFailure(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	base := varnishadm.NewMock(6082, "secret", logger)
+	base.SetResponse("vcl.list", varnishadm.NewVarnishResponse(varnishadm.ClisOk, "active      auto/warm          - boot"))
+	mock := &flakyVarnishadm{MockVarnishadm: base, fail: true}
+
+	tmpDir := t.TempDir()
+	vclPath := filepath.Join(tmpDir, "main.vcl")
+
+	client := fake.NewSimpleClientset()
+	r := New(mock, vclPath, 3, client, "test-cm", "default", logger)
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-cm",
+			Namespace:       "default",
+			ResourceVersion: "5",
+		},
+		Data: map[string]string{
+			"main.vcl": "vcl 4.1; # v1",
+		},
+	}
+
+	// First delivery: ReloadInline fails (injected compilation error).
+	r.handleConfigMapUpdate(cm)
+
+	r.lastVCLMux.RLock()
+	rvAfterFailure := r.lastConfigMapRV
+	vclAfterFailure := r.lastVCL
+	r.lastVCLMux.RUnlock()
+
+	if rvAfterFailure == cm.ResourceVersion {
+		t.Fatalf("lastConfigMapRV must not advance to %q after a failed reload (would strand the dedup check and block retries)", cm.ResourceVersion)
+	}
+	if vclAfterFailure == cm.Data["main.vcl"] {
+		t.Fatal("lastVCL must not advance to the new content after a failed reload")
+	}
+
+	historyBeforeRetry := len(base.GetCallHistory())
+
+	// Second delivery: the SAME object (identical ResourceVersion "5"), as
+	// would happen on an informer resync. The reload now succeeds. Because
+	// lastConfigMapRV was never advanced above, this must NOT be skipped by
+	// the RV-dedup check - it must retry the reload.
+	mock.fail = false
+	r.handleConfigMapUpdate(cm)
+
+	history := base.GetCallHistory()
+	if len(history) <= historyBeforeRetry {
+		t.Fatalf("expected a retry to issue new varnishadm commands after the earlier failure; history: %v", history)
+	}
+
+	var foundInline bool
+	for _, cmd := range history[historyBeforeRetry:] {
+		if strings.HasPrefix(cmd, "vcl.inline vcl_") {
+			foundInline = true
+		}
+	}
+	if !foundInline {
+		t.Errorf("expected retry to call vcl.inline; history: %v", history)
+	}
+
+	r.lastVCLMux.RLock()
+	rvAfterRetry := r.lastConfigMapRV
+	vclAfterRetry := r.lastVCL
+	r.lastVCLMux.RUnlock()
+
+	if rvAfterRetry != cm.ResourceVersion {
+		t.Errorf("expected lastConfigMapRV to advance to %q after a successful retry, got %q", cm.ResourceVersion, rvAfterRetry)
+	}
+	if vclAfterRetry != cm.Data["main.vcl"] {
+		t.Error("expected lastVCL to be updated after a successful retry")
 	}
 }

--- a/internal/vrun/logwriter.go
+++ b/internal/vrun/logwriter.go
@@ -24,17 +24,24 @@ type logWriter struct {
 	pw *io.PipeWriter
 }
 
-// newLogWriter creates a new log writer for varnishd output.
-// The ready channel is closed when varnishd signals it's ready to receive traffic.
-// The caller must call Close() when done to release the scanner goroutine.
-func newLogWriter(logger *slog.Logger, source string, ready chan<- struct{}) *logWriter {
-	pr, pw := io.Pipe()
+// maxLogLineSize is the maximum token size the scanner will buffer before
+// treating a line as overlong. Raised well above the default varnishd log
+// line length to avoid spurious ErrTooLong, while still bounding memory use.
+const maxLogLineSize = 8 * 1024 * 1024 // 8MB max token size
 
-	var readyOnce sync.Once
+// newLogWriter creates a new log writer for varnishd output.
+// The ready channel is closed (via readyOnce) when varnishd signals it's ready
+// to receive traffic. readyOnce MUST be shared across all logWriters that were
+// handed the same ready channel (e.g. stdout and stderr), otherwise each
+// writer's own sync.Once only dedupes closes within its own stream, and a
+// close from the "other" stream will panic on the already-closed channel.
+// The caller must call Close() when done to release the scanner goroutine.
+func newLogWriter(logger *slog.Logger, source string, ready chan<- struct{}, readyOnce *sync.Once) *logWriter {
+	pr, pw := io.Pipe()
 
 	go func() {
 		scanner := bufio.NewScanner(pr)
-		scanner.Buffer(make([]byte, 64*1024), 1024*1024) // 1MB max token size
+		scanner.Buffer(make([]byte, 64*1024), maxLogLineSize)
 		for scanner.Scan() {
 			line := strings.TrimSpace(scanner.Text())
 			if line == "" {
@@ -51,7 +58,9 @@ func newLogWriter(logger *slog.Logger, source string, ready chan<- struct{}) *lo
 				// Info from child process about starting, treat as debug
 				level = slog.LevelDebug
 
-				// Signal readiness and log milestone
+				// Signal readiness and log milestone. readyOnce is shared across
+				// both the stdout and stderr logWriters so the channel is closed
+				// at most once regardless of which stream the line appears on.
 				readyOnce.Do(func() {
 					close(ready)
 				})
@@ -76,7 +85,14 @@ func newLogWriter(logger *slog.Logger, source string, ready chan<- struct{}) *lo
 			logger.Log(context.Background(), level, line, "source", source)
 		}
 		if err := scanner.Err(); err != nil {
-			logger.Error("log scanner error", "source", source, "error", err)
+			// The scanner gave up (e.g. bufio.ErrTooLong on an overlong line).
+			// io.Pipe is synchronous: if we stop reading here, the next Write
+			// from varnishd blocks forever, and once the OS pipe buffer fills
+			// varnishd itself blocks - stalling the data plane. Keep draining
+			// the pipe (discarding data) so the writer side never blocks, even
+			// though we can no longer log individual lines.
+			logger.Error("log scanner error, draining remaining output without further line logging", "source", source, "error", err)
+			_, _ = io.Copy(io.Discard, pr)
 		}
 	}()
 

--- a/internal/vrun/logwriter_test.go
+++ b/internal/vrun/logwriter_test.go
@@ -1,8 +1,11 @@
 package vrun
 
 import (
+	"bytes"
+	"io"
 	"log/slog"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -11,7 +14,8 @@ import (
 // Write calls is correctly reassembled and the ready channel is closed.
 func TestLogWriter_SplitLine(t *testing.T) {
 	ready := make(chan struct{})
-	lw := newLogWriter(slog.Default(), "test", ready)
+	var readyOnce sync.Once
+	lw := newLogWriter(slog.Default(), "test", ready, &readyOnce)
 	defer lw.Close()
 
 	// Write the readiness line in two fragments
@@ -34,7 +38,8 @@ func TestLogWriter_SplitLine(t *testing.T) {
 // call closes the ready channel.
 func TestLogWriter_CompleteLine(t *testing.T) {
 	ready := make(chan struct{})
-	lw := newLogWriter(slog.Default(), "test", ready)
+	var readyOnce sync.Once
+	lw := newLogWriter(slog.Default(), "test", ready, &readyOnce)
 	defer lw.Close()
 
 	if _, err := lw.Write([]byte("Info: Child (5678) said Child starts\n")); err != nil {
@@ -54,7 +59,8 @@ func TestLogWriter_CompleteLine(t *testing.T) {
 // hangs occur.
 func TestLogWriter_LogLevels(t *testing.T) {
 	ready := make(chan struct{})
-	lw := newLogWriter(slog.Default(), "test", ready)
+	var readyOnce sync.Once
+	lw := newLogWriter(slog.Default(), "test", ready, &readyOnce)
 	defer lw.Close()
 
 	lines := []string{
@@ -89,7 +95,8 @@ func TestLogWriter_LogLevels(t *testing.T) {
 // bufio.Scanner limit are handled correctly with the increased buffer.
 func TestLogWriter_OversizedLine(t *testing.T) {
 	ready := make(chan struct{})
-	lw := newLogWriter(slog.Default(), "test", ready)
+	var readyOnce sync.Once
+	lw := newLogWriter(slog.Default(), "test", ready, &readyOnce)
 	defer lw.Close()
 
 	// Create a line larger than the default 64KB scanner limit
@@ -108,5 +115,97 @@ func TestLogWriter_OversizedLine(t *testing.T) {
 		// success - scanner survived the oversized line
 	case <-time.After(2 * time.Second):
 		t.Fatal("scanner goroutine died after oversized line; ready channel never closed")
+	}
+}
+
+// TestLogWriter_SharedReadyOnce verifies that two logWriters sharing the same
+// ready channel and the same *sync.Once do not panic when the readiness line
+// appears on both streams (M-17). Without a shared Once, each writer's own
+// internal Once only dedupes closes within its own stream, and the second
+// close(ready) from the "other" stream panics.
+func TestLogWriter_SharedReadyOnce(t *testing.T) {
+	ready := make(chan struct{})
+	var readyOnce sync.Once
+
+	stdout := newLogWriter(slog.Default(), "stdout", ready, &readyOnce)
+	stderr := newLogWriter(slog.Default(), "stderr", ready, &readyOnce)
+	defer stdout.Close()
+	defer stderr.Close()
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panic from double-close of ready channel: %v", r)
+		}
+	}()
+
+	// Simulate the readiness line showing up on BOTH stdout and stderr, as can
+	// legitimately happen with varnishd/the mgt process duplicating output.
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		_, _ = stdout.Write([]byte("Info: Child (1111) said Child starts\n"))
+	}()
+	go func() {
+		defer wg.Done()
+		_, _ = stderr.Write([]byte("Info: Child (1111) said Child starts\n"))
+	}()
+	wg.Wait()
+
+	select {
+	case <-ready:
+		// success
+	case <-time.After(2 * time.Second):
+		t.Fatal("ready channel was not closed")
+	}
+
+	// Give both scanner goroutines a moment to process; if the second close
+	// were going to panic, it would have happened by now (and the deferred
+	// recover above would have caught it).
+	time.Sleep(100 * time.Millisecond)
+}
+
+// TestLogWriter_OverlongLineDrains verifies that a line exceeding the scanner's
+// max token size does not deadlock the pipe (M-18). After a scan error, the
+// goroutine must keep draining the pipe to EOF so that writes on the other
+// end (varnishd) never block. We verify this by writing far more data than
+// the OS pipe buffer can hold without a reader; if draining stopped, this
+// write would block forever and the test would time out.
+func TestLogWriter_OverlongLineDrains(t *testing.T) {
+	ready := make(chan struct{})
+	var readyOnce sync.Once
+	lw := newLogWriter(slog.Default(), "test", ready, &readyOnce)
+	defer lw.Close()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+
+		// A single "line" (no newline) larger than maxLogLineSize forces
+		// bufio.Scanner to fail with ErrTooLong.
+		overlong := bytes.Repeat([]byte("x"), maxLogLineSize+1)
+		if _, err := lw.Write(overlong); err != nil && err != io.ErrClosedPipe {
+			t.Errorf("Write(overlong): %v", err)
+			return
+		}
+
+		// Keep writing well beyond typical OS pipe buffer sizes (usually
+		// 64KB-1MB). If the scanner goroutine stopped draining after the
+		// ErrTooLong, one of these writes would block forever and the test
+		// would hang until the outer timeout fires.
+		chunk := bytes.Repeat([]byte("y"), 256*1024)
+		for i := 0; i < 32; i++ {
+			if _, err := lw.Write(chunk); err != nil {
+				t.Errorf("Write(chunk %d): %v", i, err)
+				return
+			}
+		}
+	}()
+
+	select {
+	case <-done:
+		// success - all writes completed without blocking
+	case <-time.After(5 * time.Second):
+		t.Fatal("writes blocked after overlong line; pipe drain goroutine likely exited without draining")
 	}
 }

--- a/internal/vrun/process.go
+++ b/internal/vrun/process.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sync"
 	"syscall"
 	"time"
 )
@@ -109,9 +110,16 @@ func (m *Manager) Start(ctx context.Context, varnishCmd string, args []string) (
 	// Create ready channel - closed when varnishd signals readiness
 	ready := make(chan struct{})
 
+	// Both the stdout and stderr logWriters can independently observe the
+	// readiness line ("Child starts"). Share a single sync.Once across both
+	// so the ready channel is closed at most once regardless of which stream
+	// the line appears on (see M-17: per-writer Once only dedupes within one
+	// stream, and a close from the other stream would panic).
+	var readyOnce sync.Once
+
 	// Route varnishd output through our structured logging
-	m.stdoutLog = newLogWriter(m.logger, "varnishd", ready)
-	m.stderrLog = newLogWriter(m.logger, "varnishd", ready)
+	m.stdoutLog = newLogWriter(m.logger, "varnishd", ready, &readyOnce)
+	m.stderrLog = newLogWriter(m.logger, "varnishd", ready, &readyOnce)
 	m.cmd.Stdout = m.stdoutLog
 	m.cmd.Stderr = m.stderrLog
 


### PR DESCRIPTION
Resolves 23 of the 24 medium-severity findings from the code review (`~/varnish-gateway-code-review.md`, §4). Follows the earlier high-severity sweep (#77). Each fix was implemented in an isolated worktree and verified before merge.

## Controllers (`internal/controller`)
- **M-1** Watch `GatewayClass` — a Gateway created before its class (or a later `parametersRef`) now reconciles instead of stalling.
- **M-2** Include container `Resources` in the infrastructure hash so `spec.resources` edits trigger a rolling restart.
- **M-3** Emit a single `ResolvedRefs` condition per listener; duplicate map-keyed conditions were rejected by the API server, causing a reconcile loop.
- **M-4** Guard nil `ConfigMap.Data` before writing `main.vcl`.
- **M-5** Apply GEP-713 precedence when selecting the data-plane `BackendTLSPolicy` so it matches the `Conflicted` status winner (was nondeterministic).
- **M-6** Key `BackendTLSPolicy` by `namespace/service/sectionName`; a port-scoped policy no longer applies to all Service ports.
- **M-7** Skip `BackendTLSPolicy` objects whose CA refs don't resolve, instead of enabling unverifiable backend TLS (502s).
- **M-11** Reject listener ports colliding with reserved internal ports (1969/6060/6082/8081/9000) via `PortUnavailable` instead of crash-looping the data plane.
- **M-12** Re-evaluate sibling `VarnishCachePolicy` objects on every reconcile (incl. deletes) so a `Conflicted` loser heals when the winner disappears.
- **M-13** Match Gateway/Route-scoped VCPs only within the target's own namespace; fixes cross-namespace policy confusion.

## Routing translation (`internal/vcl`, `internal/ghost`)
- **M-8** Default `backendRef.weight` to 1 (spec) in both branches.
- **M-9** Normalize a no-match rule to nil pathMatch so it ties with an explicit `PathPrefix /` rather than always winning.
- **M-10** Drop `backendTLS` from the ghost merge key so mixed TLS/plaintext backends merge into one route with correct weighted groups.
- **M-24** Emit a match-nothing sentinel when a `parentRef` filter resolves to no listener, instead of failing open to "all listeners".

## Chaperone data plane (`internal/vrun`, `internal/tls`, `internal/vcl`, `internal/invalidation`, `ghost`)
- **M-14** Require `VarnishCacheInvalidation` to target a gateway in its own namespace before purging/banning.
- **M-16** Send a single upstream `Host` header from the external proxy (reqwest `.header()` appends).
- **M-17** Share one `sync.Once` for the readiness channel across both log streams to avoid a double-close panic.
- **M-18** Keep draining varnishd output after an over-long line instead of deadlocking the pipe; raise scan buffer to 8 MiB.
- **M-19** Treat PURGE `404` (Not in cache) as success.
- **M-20** Record a CR as processed only after its status write succeeds; use `apierrors.IsConflict` and bounded backoff.
- **M-21** Validate invalidation hostname (RFC 1123) and paths before use; add CRD validation markers — prevents ban-expression injection.
- **M-22** Advance the ConfigMap `ResourceVersion` only after a successful VCL reload so a transient failure retries instead of stranding stale VCL.
- **M-23** Skip TLS cert rollback on comms-ambiguous errors (matching `LoadAll`), via shared load/commit helpers.

## Not changed
- **M-15** Serving 500 when a weighted backend group has no endpoints is a **deliberate, documented, spec-compliant** choice (no redistribution, matching Envoy Gateway). The proposed fix would redistribute traffic, contradicting `AGENTS.md` and the Gateway API spec. Left as-is by design.

## Verification
- `gofmt` / `go vet` / `go build` clean
- `go test ./...` and the envtest integration suite (`make test-go`) pass
- `make manifests` regenerated the `VarnishCacheInvalidation` CRD (M-21 validation markers)
- ghost: `cargo test` (94 passed) + `clippy` clean
- **Gateway API conformance** (`make test-conformance-kind`, isolated kind cluster built from this branch): **47 passed, 0 failed**, 83 skipped (unsupported optional features). Report: `Core tests succeeded. Extended tests succeeded.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)