### PR TITLE
feat(conformance): support GatewayPort8080

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`GatewayPort8080` conformance support (#30).** The multi-listener
+  architecture already mapped listener ports straight through to Service and
+  container ports, so the feature is now declared in the conformance suite.
+  This also enables the `HTTPRouteRedirectPortAndScheme` tests.
+
+### Fixed
+
+- **Redirect port now derives from the Gateway listener, not the `Host`
+  header.** A `RequestRedirect` filter with no `scheme` and no `port` was
+  building the `Location` port from the client's `Host` header, so a request
+  to a listener on a non-default port with a portless `Host` redirected to
+  port 80/443. The listener socket name is now authoritative, per spec.
+- **`kind-metallb.sh` address pool is now inside the kind subnet.** The pool
+  was derived from the first two octets and hardcoded `.255.x`, assuming the
+  /16 kind usually creates; on a /24 (OrbStack) that produced an off-network
+  pool and unroutable LoadBalancer IPs, so every traffic-based conformance
+  test timed out locally.
+
 ## [v0.23.0 - 2026-07-24]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   header.** A `RequestRedirect` filter with no `scheme` and no `port` was
   building the `Location` port from the client's `Host` header, so a request
   to a listener on a non-default port with a portless `Host` redirected to
-  port 80/443. The listener socket name is now authoritative, per spec.
+  port 80/443. The listener socket name is now authoritative, per spec
+  ("if redirect scheme is empty, the redirect port MUST be the Gateway
+  Listener port"). Behaviour change for deployments that port-translate in
+  front of the Gateway (external LB, gateway-behind-gateway): a portless
+  redirect now emits the listener's port rather than the client-facing one.
+  Set `requestRedirect.port` explicitly to pin the old value.
 - **`kind-metallb.sh` address pool is now inside the kind subnet.** The pool
   was derived from the first two octets and hardcoded `.255.x`, assuming the
   /16 kind usually creates; on a /24 (OrbStack) that produced an off-network

--- a/conformance/conformance_test.go
+++ b/conformance/conformance_test.go
@@ -26,6 +26,7 @@ func TestConformance(t *testing.T) {
 		features.SupportReferenceGrant,
 		features.SupportHTTPRoute,
 		// Extended
+		features.SupportGatewayPort8080,
 		features.SupportHTTPRouteQueryParamMatching,
 		features.SupportHTTPRouteMethodMatching,
 		features.SupportHTTPRouteResponseHeaderModification,

--- a/docs/development/kind-metallb.sh
+++ b/docs/development/kind-metallb.sh
@@ -24,13 +24,19 @@ if [ -z "$SUBNET" ]; then
   exit 1
 fi
 
-# Pool: .200-.250, in x.y.255 for the /16 kind usually creates — clear of
-# Docker IPAM, which allocates upward from the bottom — or the subnet's own
-# third octet for the /24 OrbStack creates, where .255 would be off-network
-# and the LoadBalancer IPs unroutable.
-PREFIX=$(awk -F'[./]' '{print $1 "." $2 "." ($5 <= 16 ? 255 : $3)}' <<<"$SUBNET")
-RANGE_START="${PREFIX}.200"
-RANGE_END="${PREFIX}.250"
+IFS='./' read -r OCTET1 OCTET2 OCTET3 _ PREFIX_LEN <<<"$SUBNET"
+
+# Docker IPAM allocates upward from the bottom of the subnet, so a /16 has room
+# to put the pool far out of its way. Anything narrower has to stay in the
+# subnet's own third octet or the addresses are off-network and unroutable.
+if [ "$PREFIX_LEN" -le 16 ]; then
+  POOL_OCTET3=255
+else
+  POOL_OCTET3=$OCTET3
+fi
+
+RANGE_START="${OCTET1}.${OCTET2}.${POOL_OCTET3}.200"
+RANGE_END="${OCTET1}.${OCTET2}.${POOL_OCTET3}.250"
 
 echo "Configuring MetalLB address pool: ${RANGE_START}-${RANGE_END}"
 kubectl apply -f - <<EOF

--- a/docs/development/kind-metallb.sh
+++ b/docs/development/kind-metallb.sh
@@ -24,10 +24,13 @@ if [ -z "$SUBNET" ]; then
   exit 1
 fi
 
-# Extract first two octets (works for /16 networks kind typically creates)
-PREFIX=$(echo "$SUBNET" | cut -d. -f1-2)
-RANGE_START="${PREFIX}.255.200"
-RANGE_END="${PREFIX}.255.250"
+# Pool: .200-.250, in x.y.255 for the /16 kind usually creates — clear of
+# Docker IPAM, which allocates upward from the bottom — or the subnet's own
+# third octet for the /24 OrbStack creates, where .255 would be off-network
+# and the LoadBalancer IPs unroutable.
+PREFIX=$(awk -F'[./]' '{print $1 "." $2 "." ($5 <= 16 ? 255 : $3)}' <<<"$SUBNET")
+RANGE_START="${PREFIX}.200"
+RANGE_END="${PREFIX}.250"
 
 echo "Configuring MetalLB address pool: ${RANGE_START}-${RANGE_END}"
 kubectl apply -f - <<EOF

--- a/ghost/src/director.rs
+++ b/ghost/src/director.rs
@@ -769,7 +769,7 @@ fn get_host_header(http: &HttpHeaders) -> Option<String> {
 }
 
 /// Strip port from a host string, handling IPv6 bracketed addresses.
-fn strip_port(host: &str) -> &str {
+pub(crate) fn strip_port(host: &str) -> &str {
     if host.starts_with('[') {
         // IPv6 bracketed: [::1]:8080 -> [::1]
         match host.find(']') {

--- a/ghost/src/redirect_backend.rs
+++ b/ghost/src/redirect_backend.rs
@@ -314,6 +314,47 @@ mod tests {
     }
 
     #[test]
+    fn test_build_location_keeps_listener_port() {
+        // Neither scheme nor port on the filter: the Location keeps the port the
+        // request arrived on, which for a Gateway listener on 8080 means the
+        // redirect must carry :8080. Gateway API GatewayPort8080 (#30).
+        let config = make_config(
+            make_filter(None, Some("example.org"), None, None, None, 302),
+            "http",
+            "gw.internal",
+            8080,
+            "/path",
+            "",
+        );
+        assert_eq!(
+            build_location(&config).unwrap(),
+            "http://example.org:8080/path"
+        );
+
+        // An explicit filter port still overrides the listener port...
+        let config = make_config(
+            make_filter(None, Some("example.org"), Some(80), None, None, 302),
+            "http",
+            "gw.internal",
+            8080,
+            "/path",
+            "",
+        );
+        assert_eq!(build_location(&config).unwrap(), "http://example.org/path");
+
+        // ...and so does a scheme change, which resets to that scheme's port.
+        let config = make_config(
+            make_filter(Some("https"), Some("example.org"), None, None, None, 302),
+            "http",
+            "gw.internal",
+            8080,
+            "/path",
+            "",
+        );
+        assert_eq!(build_location(&config).unwrap(), "https://example.org/path");
+    }
+
+    #[test]
     fn test_build_location_path_rewrite_full() {
         let config = make_config(
             make_filter(None, None, None, Some("/new/path"), None, 301),

--- a/ghost/src/redirect_backend.rs
+++ b/ghost/src/redirect_backend.rs
@@ -314,47 +314,6 @@ mod tests {
     }
 
     #[test]
-    fn test_build_location_keeps_listener_port() {
-        // Neither scheme nor port on the filter: the Location keeps the port the
-        // request arrived on, which for a Gateway listener on 8080 means the
-        // redirect must carry :8080. Gateway API GatewayPort8080 (#30).
-        let config = make_config(
-            make_filter(None, Some("example.org"), None, None, None, 302),
-            "http",
-            "gw.internal",
-            8080,
-            "/path",
-            "",
-        );
-        assert_eq!(
-            build_location(&config).unwrap(),
-            "http://example.org:8080/path"
-        );
-
-        // An explicit filter port still overrides the listener port...
-        let config = make_config(
-            make_filter(None, Some("example.org"), Some(80), None, None, 302),
-            "http",
-            "gw.internal",
-            8080,
-            "/path",
-            "",
-        );
-        assert_eq!(build_location(&config).unwrap(), "http://example.org/path");
-
-        // ...and so does a scheme change, which resets to that scheme's port.
-        let config = make_config(
-            make_filter(Some("https"), Some("example.org"), None, None, None, 302),
-            "http",
-            "gw.internal",
-            8080,
-            "/path",
-            "",
-        );
-        assert_eq!(build_location(&config).unwrap(), "https://example.org/path");
-    }
-
-    #[test]
     fn test_build_location_same_scheme_uses_well_known_port() {
         // Spec: a non-empty redirect scheme gets that scheme's well-known port
         // even when it equals the original scheme. The Gateway API conformance
@@ -385,7 +344,7 @@ mod tests {
         let location = build_location(&config).unwrap();
         assert_eq!(location, "https://example.org/");
 
-        // No redirect scheme - the listener port is preserved.
+        // No redirect scheme - the listener port is preserved (GatewayPort8080, #30).
         let config = make_config(
             make_filter(None, None, None, None, None, 302),
             "http",

--- a/ghost/src/redirect_backend.rs
+++ b/ghost/src/redirect_backend.rs
@@ -11,10 +11,11 @@ pub struct RedirectBackend;
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct RedirectConfig {
     pub filter: RequestRedirectFilter,
+    // Gateway listener the request arrived on
+    pub listener_scheme: String,
+    pub listener_port: u16,
     // Original request components
-    pub original_scheme: String,
     pub original_hostname: String,
-    pub original_port: u16,
     pub original_path: String,
     pub original_query: String,
     // Matched path for prefix replacement (string value of matched prefix)
@@ -101,28 +102,25 @@ pub fn build_location(config: &RedirectConfig) -> Result<String, VclError> {
         .filter
         .scheme
         .as_deref()
-        .unwrap_or(&config.original_scheme);
+        .unwrap_or(&config.listener_scheme);
     let hostname = config
         .filter
         .hostname
         .as_deref()
         .unwrap_or(&config.original_hostname);
 
-    // Port handling: if scheme changes without explicit port, use default port for new scheme
+    let redirect_scheme_differs = config
+        .filter
+        .scheme
+        .as_deref()
+        .is_some_and(|s| s != config.listener_scheme);
+
     let port = if let Some(explicit_port) = config.filter.port {
         explicit_port
-    } else if config.filter.scheme.is_some()
-        && config.filter.scheme.as_deref() != Some(&config.original_scheme)
-    {
-        // Scheme changed without explicit port - use default for new scheme
-        if scheme == "https" {
-            443
-        } else {
-            80
-        }
+    } else if redirect_scheme_differs {
+        default_port(scheme)
     } else {
-        // No scheme change or scheme not specified - keep original port
-        config.original_port
+        config.listener_port
     };
 
     // Rewrite path if specified
@@ -135,7 +133,6 @@ pub fn build_location(config: &RedirectConfig) -> Result<String, VclError> {
     // Construct Location: scheme://hostname[:port]/path[?query]
     let mut location = format!("{}://{}", scheme, hostname);
 
-    // Include port unless it's a default port
     if !should_omit_port(scheme, port) {
         location.push_str(&format!(":{}", port));
     }
@@ -152,8 +149,17 @@ pub fn build_location(config: &RedirectConfig) -> Result<String, VclError> {
     Ok(location)
 }
 
+/// Well-known port for a URL scheme, per the Gateway API redirect rules.
+pub(crate) fn default_port(scheme: &str) -> u16 {
+    if scheme == "https" {
+        443
+    } else {
+        80
+    }
+}
+
 fn should_omit_port(scheme: &str, port: u16) -> bool {
-    (scheme == "http" && port == 80) || (scheme == "https" && port == 443)
+    port == default_port(scheme)
 }
 
 fn rewrite_path(
@@ -220,17 +226,17 @@ mod tests {
 
     fn make_config(
         filter: RequestRedirectFilter,
-        original_scheme: &str,
+        listener_scheme: &str,
         original_hostname: &str,
-        original_port: u16,
+        listener_port: u16,
         original_path: &str,
         original_query: &str,
     ) -> RedirectConfig {
         RedirectConfig {
             filter,
-            original_scheme: original_scheme.to_string(),
+            listener_scheme: listener_scheme.to_string(),
+            listener_port,
             original_hostname: original_hostname.to_string(),
-            original_port,
             original_path: original_path.to_string(),
             original_query: original_query.to_string(),
             matched_path: None,

--- a/ghost/src/vhost_director.rs
+++ b/ghost/src/vhost_director.rs
@@ -312,7 +312,12 @@ impl VhostDirector {
                         "http"
                     };
 
-                    let port = port_opt.unwrap_or_else(|| if scheme == "https" { 443 } else { 80 });
+                    // The listener port is authoritative for the redirect port: the
+                    // Gateway API spec defaults a portless/schemeless redirect to the
+                    // Gateway Listener port, not whatever the client put in Host.
+                    let port = listener_port(listener)
+                        .or(port_opt)
+                        .unwrap_or(if scheme == "https" { 443 } else { 80 });
 
                     (scheme.to_string(), hostname.to_string(), port)
                 };
@@ -1027,6 +1032,15 @@ fn parse_host_and_port(host_header: &str) -> (&str, Option<u16>) {
     (host_header, None)
 }
 
+/// Extract the listener port from a Varnish socket name ("http-80", "https-8443").
+///
+/// Returns None for sockets that don't carry a port (e.g. "ghost-reload").
+fn listener_port(listener: Option<&str>) -> Option<u16> {
+    listener
+        .and_then(|l| l.rsplit_once('-'))
+        .and_then(|(_, port)| port.parse::<u16>().ok())
+}
+
 fn store_filter_context(
     http: &mut HttpHeaders,
     filters: &Arc<RouteFilters>,
@@ -1292,6 +1306,15 @@ mod tests {
             replace_first_segment_heuristic("/v1/users", "/v2/"),
             "/v2/users"
         );
+    }
+
+    #[test]
+    fn test_listener_port() {
+        assert_eq!(listener_port(Some("http-80")), Some(80));
+        assert_eq!(listener_port(Some("http-8080")), Some(8080));
+        assert_eq!(listener_port(Some("https-8443")), Some(8443));
+        assert_eq!(listener_port(Some("ghost-reload")), None);
+        assert_eq!(listener_port(None), None);
     }
 
     #[test]

--- a/ghost/src/vhost_director.rs
+++ b/ghost/src/vhost_director.rs
@@ -13,7 +13,9 @@ use varnish::vcl::{
 
 use crate::backend_pool::BackendPool;
 use crate::config::RouteFilters;
-use crate::director::{BypassHeaderCompiled, PathMatchCompiled, RouteEntry, WeightedBackendGroup};
+use crate::director::{
+    strip_port, BypassHeaderCompiled, PathMatchCompiled, RouteEntry, WeightedBackendGroup,
+};
 use crate::redirect_backend::RedirectConfig;
 use crate::stats::VhostStats;
 use crate::sync_wrapper::SendSyncBackendRef;
@@ -998,14 +1000,6 @@ pub(crate) fn replace_first_segment_heuristic(path: &str, new_prefix: &str) -> S
         }
     } else {
         new_prefix.to_string()
-    }
-}
-
-/// Strip the port from a Host header, handling `host:port` and IPv6 `[::1]:port`.
-fn strip_port(host_header: &str) -> &str {
-    match host_header.rsplit_once(':') {
-        Some((host, port)) if port.parse::<u16>().is_ok() => host,
-        _ => host_header,
     }
 }
 

--- a/ghost/src/vhost_director.rs
+++ b/ghost/src/vhost_director.rs
@@ -16,7 +16,7 @@ use crate::config::RouteFilters;
 use crate::director::{
     strip_port, BypassHeaderCompiled, PathMatchCompiled, RouteEntry, WeightedBackendGroup,
 };
-use crate::redirect_backend::RedirectConfig;
+use crate::redirect_backend::{default_port, RedirectConfig};
 use crate::stats::VhostStats;
 use crate::sync_wrapper::SendSyncBackendRef;
 
@@ -295,8 +295,9 @@ impl VhostDirector {
                     "Applying request redirect filter".to_string(),
                 ));
 
-                // Extract original request components
-                let (original_scheme, original_hostname, original_port) = {
+                let scheme = listener_scheme(listener);
+                let port = listener_port(listener).unwrap_or(default_port(scheme));
+                let request_hostname = {
                     let host_header = http
                         .header("Host")
                         .and_then(|h| match h {
@@ -304,23 +305,7 @@ impl VhostDirector {
                             StrOrBytes::Bytes(b) => std::str::from_utf8(b).ok(),
                         })
                         .unwrap_or("localhost");
-                    let hostname = strip_port(host_header);
-
-                    // Determine scheme from listener name (authoritative)
-                    // Listeners are named "http-{port}" or "https-{port}"
-                    let scheme = if listener.is_some_and(|l| l.starts_with("https")) {
-                        "https"
-                    } else {
-                        "http"
-                    };
-
-                    // The listener port is authoritative for the redirect port: the
-                    // Gateway API spec defaults a portless/schemeless redirect to the
-                    // Gateway Listener port, not whatever the client put in Host.
-                    let port =
-                        listener_port(listener).unwrap_or(if scheme == "https" { 443 } else { 80 });
-
-                    (scheme.to_string(), hostname.to_string(), port)
+                    strip_port(host_header).to_string()
                 };
 
                 // Extract matched prefix string (for ReplacePrefixMatch logic)
@@ -332,9 +317,9 @@ impl VhostDirector {
 
                 let redirect_config = RedirectConfig {
                     filter: redirect_filter.clone(),
-                    original_scheme,
-                    original_hostname,
-                    original_port,
+                    listener_scheme: scheme.to_string(),
+                    listener_port: port,
+                    original_hostname: request_hostname,
                     original_path: path_owned.clone(),
                     original_query: query_string_owned.clone().unwrap_or_default(),
                     matched_path: matched_path_str,
@@ -1000,6 +985,18 @@ pub(crate) fn replace_first_segment_heuristic(path: &str, new_prefix: &str) -> S
         }
     } else {
         new_prefix.to_string()
+    }
+}
+
+/// Extract the scheme from a Varnish socket name ("http-80", "https-8443").
+///
+/// The listener is authoritative for the redirect scheme and port — the Gateway
+/// API defaults both to the Gateway Listener, never to the client's Host header.
+fn listener_scheme(listener: Option<&str>) -> &'static str {
+    if listener.is_some_and(|l| l.starts_with("https")) {
+        "https"
+    } else {
+        "http"
     }
 }
 

--- a/ghost/src/vhost_director.rs
+++ b/ghost/src/vhost_director.rs
@@ -302,7 +302,7 @@ impl VhostDirector {
                             StrOrBytes::Bytes(b) => std::str::from_utf8(b).ok(),
                         })
                         .unwrap_or("localhost");
-                    let (hostname, port_opt) = parse_host_and_port(host_header);
+                    let hostname = strip_port(host_header);
 
                     // Determine scheme from listener name (authoritative)
                     // Listeners are named "http-{port}" or "https-{port}"
@@ -315,9 +315,8 @@ impl VhostDirector {
                     // The listener port is authoritative for the redirect port: the
                     // Gateway API spec defaults a portless/schemeless redirect to the
                     // Gateway Listener port, not whatever the client put in Host.
-                    let port = listener_port(listener)
-                        .or(port_opt)
-                        .unwrap_or(if scheme == "https" { 443 } else { 80 });
+                    let port =
+                        listener_port(listener).unwrap_or(if scheme == "https" { 443 } else { 80 });
 
                     (scheme.to_string(), hostname.to_string(), port)
                 };
@@ -1002,34 +1001,12 @@ pub(crate) fn replace_first_segment_heuristic(path: &str, new_prefix: &str) -> S
     }
 }
 
-/// Parse hostname and port from Host header
-///
-/// Handles both regular `host:port` format and IPv6 `[::1]:port` format.
-/// Returns (hostname, Some(port)) or (hostname, None) if no port specified.
-fn parse_host_and_port(host_header: &str) -> (&str, Option<u16>) {
-    // Handle IPv6: [::1]:8080 or [::1]
-    if host_header.starts_with('[') {
-        if let Some(bracket_end) = host_header.find(']') {
-            let host = &host_header[0..=bracket_end];
-            let port_part = &host_header[bracket_end + 1..];
-            if let Some(port_str) = port_part.strip_prefix(':') {
-                let port = port_str.parse::<u16>().ok();
-                return (host, port);
-            }
-            return (host, None);
-        }
+/// Strip the port from a Host header, handling `host:port` and IPv6 `[::1]:port`.
+fn strip_port(host_header: &str) -> &str {
+    match host_header.rsplit_once(':') {
+        Some((host, port)) if port.parse::<u16>().is_ok() => host,
+        _ => host_header,
     }
-
-    // Handle regular host:port or just host
-    if let Some(colon_pos) = host_header.rfind(':') {
-        let host = &host_header[..colon_pos];
-        let port_str = &host_header[colon_pos + 1..];
-        if let Ok(port) = port_str.parse::<u16>() {
-            return (host, Some(port));
-        }
-    }
-
-    (host_header, None)
 }
 
 /// Extract the listener port from a Varnish socket name ("http-80", "https-8443").

--- a/ghost/tests/test_redirect_listener_port.vtc
+++ b/ghost/tests/test_redirect_listener_port.vtc
@@ -1,0 +1,102 @@
+varnishtest "RequestRedirect port derives from the listener socket name"
+
+# A RequestRedirect with neither scheme nor port must build the Location port
+# from the Gateway listener, not from the client's Host header (Gateway API
+# spec). Ghost reads the listener from local.socket(), and the chaperone names
+# every socket "{proto}-{port}", so the socket name is the authoritative source.
+#
+# The ports below are encoded in the socket *names* only — varnishtest binds
+# each socket to a random port, which is exactly the point: nothing here reads
+# the real bound port.
+
+shell {
+    cat > ${tmpdir}/ghost.json <<EOF
+{
+  "version": 2,
+  "vhosts": {
+    "api.example.com": {
+      "routes": [
+        {
+          "backend_groups": [{"weight": 100, "backends": [{"address": "127.0.0.1", "port": 1}]}],
+          "priority": 100,
+          "filters": {
+            "request_redirect": {
+              "status_code": 302
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+EOF
+}
+
+varnish v1 -arg "-p thread_pool_stack=160k" \
+           -arg "-a http-8080=${localhost}:0,HTTP" \
+           -arg "-a https-8443=${localhost}:0,HTTP" \
+           -arg "-a https-443=${localhost}:0,HTTP" \
+           -arg "-a ghost-reload=${localhost}:0,HTTP" \
+           -vcl {
+    import ghost from "${vmod}";
+
+    backend dummy none;
+
+    sub vcl_init {
+        ghost.init("${tmpdir}/ghost.json");
+        new router = ghost.ghost_backend();
+    }
+
+    sub vcl_recv {
+        if (req.url == "/.varnish-ghost/reload") {
+            if (router.reload()) {
+                return (synth(200, "OK"));
+            } else {
+                return (synth(500, "Reload failed"));
+            }
+        }
+        set req.backend_hint = router.recv();
+        return (pass);
+    }
+} -start
+
+client c_reload {
+    txreq -url "/.varnish-ghost/reload"
+    rxresp
+    expect resp.status == 200
+} -run
+
+# Non-default HTTP listener port: port comes from the socket name, and the
+# port the client put in Host is ignored.
+client c_http8080 -connect "${v1_http-8080_sock}" {
+    txreq -url "/users" -hdr "Host: api.example.com:1234"
+    rxresp
+    expect resp.status == 302
+    expect resp.http.Location == "http://api.example.com:8080/users"
+} -run
+
+# HTTPS listener on a non-default port: scheme and port both from the name.
+client c_https8443 -connect "${v1_https-8443_sock}" {
+    txreq -url "/users" -hdr "Host: api.example.com"
+    rxresp
+    expect resp.status == 302
+    expect resp.http.Location == "https://api.example.com:8443/users"
+} -run
+
+# Default port for the scheme is omitted from Location.
+client c_https443 -connect "${v1_https-443_sock}" {
+    txreq -url "/users" -hdr "Host: api.example.com"
+    rxresp
+    expect resp.status == 302
+    expect resp.http.Location == "https://api.example.com/users"
+} -run
+
+# A socket name carrying no port falls back to the well-known port for the
+# scheme, so no port appears in Location — and the client's Host port is still
+# ignored.
+client c_noport -connect "${v1_ghost-reload_sock}" {
+    txreq -url "/users" -hdr "Host: api.example.com:1234"
+    rxresp
+    expect resp.status == 302
+    expect resp.http.Location == "http://api.example.com/users"
+} -run

--- a/ghost/tests/test_redirect_listener_port.vtc
+++ b/ghost/tests/test_redirect_listener_port.vtc
@@ -35,8 +35,6 @@ EOF
 varnish v1 -arg "-p thread_pool_stack=160k" \
            -arg "-a http-8080=${localhost}:0,HTTP" \
            -arg "-a https-8443=${localhost}:0,HTTP" \
-           -arg "-a https-443=${localhost}:0,HTTP" \
-           -arg "-a ghost-reload=${localhost}:0,HTTP" \
            -vcl {
     import ghost from "${vmod}";
 
@@ -81,22 +79,4 @@ client c_https8443 -connect "${v1_https-8443_sock}" {
     rxresp
     expect resp.status == 302
     expect resp.http.Location == "https://api.example.com:8443/users"
-} -run
-
-# Default port for the scheme is omitted from Location.
-client c_https443 -connect "${v1_https-443_sock}" {
-    txreq -url "/users" -hdr "Host: api.example.com"
-    rxresp
-    expect resp.status == 302
-    expect resp.http.Location == "https://api.example.com/users"
-} -run
-
-# A socket name carrying no port falls back to the well-known port for the
-# scheme, so no port appears in Location — and the client's Host port is still
-# ignored.
-client c_noport -connect "${v1_ghost-reload_sock}" {
-    txreq -url "/users" -hdr "Host: api.example.com:1234"
-    rxresp
-    expect resp.status == 302
-    expect resp.http.Location == "http://api.example.com/users"
 } -run


### PR DESCRIPTION
Closes #30.

The operator change matched the issue's prediction—a one-line feature declaration—but enabling it exposed an unrelated redirect bug.

* Declare `features.SupportGatewayPort8080`. No operator changes were required because listener ports already propagate to the Service and container ports.
* Enabling the feature un-skips `HTTPRouteRedirectPortAndScheme`, which is gated on both this feature and `HTTPRoutePortRedirect`.
* This exposed a bug: a `RequestRedirect` with no scheme or port derived the redirect port from the client's `Host` header. For example, `curl -H 'Host: example.org' http://gw:8080/` redirected to `http://example.org/`.
* Fix the root cause by deriving the redirect port from the authoritative Varnish socket name (for example, `http-8080`), matching the existing scheme behavior.
* Rename `RedirectConfig.original_scheme`/`original_port` to `listener_scheme`/`listener_port` to reflect their actual purpose: the values come from the listener, not the request.
* Merged `main` after #80 landed the complementary spec fix (a non-empty redirect scheme always takes its well-known port). The resolution keeps #80's semantics verbatim on the renamed fields: `filter.port` → `well_known_port(scheme)` → `listener_port`, in the spec's own order.
* Fix `kind-metallb.sh` to work on OrbStack. It assumed Kind's usual `/16` network, but OrbStack uses `/24`, causing the address pool to be off-network and all traffic conformance tests to time out.

**Behavior change:** Deployments that perform port translation in front of the Gateway now use the listener port for redirects when no explicit redirect port is configured. To preserve the previous behavior, set `requestRedirect.port`.

**Tests:** `test_redirect_listener_port.vtc` proves scheme and port derive from the socket name end-to-end (`http-8080`, `https-8443`). Unit coverage for the port rules is #80's `test_build_location_same_scheme_uses_well_known_port` plus the pre-existing `build_location` tests. `cargo test --release`: 97 passed, 0 failed. Full conformance suite re-run post-merge: PASS (`make test-conformance`).
