### PR TITLE
fix(ghost): use well-known redirect port when scheme is unchanged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **RequestRedirect: redirect port when the scheme is unchanged.** A
+  `requestRedirect` filter that set `scheme` without `port` only substituted the
+  scheme's well-known port when the redirect scheme differed from the request
+  scheme. The Gateway API spec assigns the well-known port (http → 80,
+  https → 443) for any non-empty redirect scheme. On a listener bound to a
+  non-standard port, `scheme: http` with no `port` emitted
+  `http://example.org:8080/` instead of `http://example.org/`. A redirect
+  scheme with no well-known port now falls back to the listener port, as the
+  spec recommends. The conformance suite does not exercise this case.
+
 ## [v0.23.0 - 2026-07-24]
 
 ### Added

--- a/ghost/src/redirect_backend.rs
+++ b/ghost/src/redirect_backend.rs
@@ -108,21 +108,23 @@ pub fn build_location(config: &RedirectConfig) -> Result<String, VclError> {
         .as_deref()
         .unwrap_or(&config.original_hostname);
 
-    // Port handling: if scheme changes without explicit port, use default port for new scheme
+    // Port handling per the Gateway API spec for HTTPRequestRedirectFilter.port:
+    //   - explicit port wins
+    //   - otherwise, if the redirect scheme is non-empty, use that scheme's
+    //     well-known port (http -> 80, https -> 443), regardless of whether it
+    //     matches the original request scheme
+    //   - a redirect scheme with no well-known port, or no redirect scheme at
+    //     all, falls back to the Gateway listener port
     let port = if let Some(explicit_port) = config.filter.port {
         explicit_port
-    } else if config.filter.scheme.is_some()
-        && config.filter.scheme.as_deref() != Some(&config.original_scheme)
-    {
-        // Scheme changed without explicit port - use default for new scheme
-        if scheme == "https" {
-            443
-        } else {
-            80
-        }
     } else {
-        // No scheme change or scheme not specified - keep original port
-        config.original_port
+        match config.filter.scheme.as_deref() {
+            Some("http") => 80,
+            Some("https") => 443,
+            // Scheme with no well-known port, or no scheme specified - keep
+            // the listener port the request arrived on.
+            _ => config.original_port,
+        }
     };
 
     // Rewrite path if specified
@@ -311,6 +313,51 @@ mod tests {
 
         let location = build_location(&config).unwrap();
         assert_eq!(location, "https://example.com:8443/path");
+    }
+
+    #[test]
+    fn test_build_location_same_scheme_uses_well_known_port() {
+        // Spec: a non-empty redirect scheme gets that scheme's well-known port
+        // even when it equals the original scheme. The Gateway API conformance
+        // suite has no scheme-http-and-port-nil case on its 8080 listener, so
+        // this case is only covered here.
+        let config = make_config(
+            make_filter(Some("http"), None, None, None, None, 302),
+            "http",
+            "example.org",
+            8080,
+            "/",
+            "",
+        );
+
+        let location = build_location(&config).unwrap();
+        assert_eq!(location, "http://example.org/");
+
+        // Same for https on a non-well-known TLS listener port.
+        let config = make_config(
+            make_filter(Some("https"), None, None, None, None, 302),
+            "https",
+            "example.org",
+            8443,
+            "/",
+            "",
+        );
+
+        let location = build_location(&config).unwrap();
+        assert_eq!(location, "https://example.org/");
+
+        // No redirect scheme - the listener port is preserved.
+        let config = make_config(
+            make_filter(None, None, None, None, None, 302),
+            "http",
+            "example.org",
+            8080,
+            "/",
+            "",
+        );
+
+        let location = build_location(&config).unwrap();
+        assert_eq!(location, "http://example.org:8080/");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`build_location` in `ghost/src/redirect_backend.rs` only substituted the redirect scheme's well-known port when the filter scheme *differed* from the request scheme:

```rust
} else if config.filter.scheme.is_some()
    && config.filter.scheme.as_deref() != Some(&config.original_scheme)
{
```

The Gateway API spec for `HTTPRequestRedirectFilter.port` has no such condition:

> * If redirect scheme is not-empty, the redirect port MUST be the well-known port associated with the redirect scheme. Specifically "http" to port 80 and "https" to port 443. If the redirect scheme does not have a well-known port, the listener port of the Gateway SHOULD be used.
> * If redirect scheme is empty, the redirect port MUST be the Gateway Listener port.

So on a listener bound to a non-standard port, `requestRedirect: {scheme: http}` with no `port` emitted `http://example.org:8080/` where the spec wants `http://example.org/`.

## Fix

Port resolution is now a direct reading of the spec — explicit port wins, otherwise the redirect scheme's well-known port, otherwise the listener port:

```rust
let port = if let Some(explicit_port) = config.filter.port {
    explicit_port
} else {
    match config.filter.scheme.as_deref() {
        Some("http") => 80,
        Some("https") => 443,
        _ => config.original_port,
    }
};
```

Two behaviour changes:

1. Same-scheme with nil port now resolves to the well-known port (the reported bug).
2. A redirect scheme with no well-known port falls back to the listener port. The old `else { 80 }` branch assigned port 80 to any non-`https` scheme; the spec says the listener port SHOULD be used. Not reachable today since the operator only accepts http/https, but the match arms make the rule explicit rather than incidental.

No change when the scheme genuinely differs — that path was already correct.

## Why conformance did not catch this

`HTTPRouteRedirectPortAndScheme` never exercises the buggy branch:

- The `same-namespace-with-http-listener-on-8080` block has only `scheme-nil-and-port-nil`, `scheme-nil-and-port-80`, and `scheme-https-and-port-nil`.
- `scheme-http-and-port-nil` appears only in the 443 block, where the scheme *does* change.
- On the 80 listener the same-scheme case passed by accident, because the original port was already 80.

Added `test_build_location_same_scheme_uses_well_known_port` covering http-on-8080, https-on-8443, and the `scheme: nil` control case that must keep 8080. Its comment records why the test exists, since conformance won't flag a regression.

## Testing

`cargo test --lib` — 78 passed. `cargo clippy --lib` clean.

Note: `cargo fmt` wants to reformat `build.rs`, `config.rs`, `director.rs`, and `external_backend.rs` — pre-existing churn on `main`, deliberately left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)