### PR TITLE
feat(timeouts): support HTTPRoute timeouts.request and timeouts.backendRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **HTTPRoute `timeouts.backendRequest` and `timeouts.request`.** A rule's
+  timeout is carried through routing.json to ghost, which bridges it onto the
+  fetch (`connect_timeout`, `first_byte_timeout`, `between_bytes_timeout`);
+  exceeding it returns 504 instead of Varnish's 503. `request` is applied as an
+  alias for `backendRequest` — when both are set the tighter value wins. `0s`
+  ("disable") falls back to varnishd's global defaults rather than running
+  unbounded. Both conformance features are now declared.
 - **`GatewayPort8080` conformance support (#30).** The multi-listener
   architecture already mapped listener ports straight through to Service and
   container ports, so the feature is now declared in the conformance suite.

--- a/conformance/conformance_test.go
+++ b/conformance/conformance_test.go
@@ -38,6 +38,7 @@ func TestConformance(t *testing.T) {
 		features.SupportHTTPRoute308RedirectStatusCode,
 		features.SupportHTTPRouteHostRewrite,
 		features.SupportHTTPRoutePathRewrite,
+		features.SupportHTTPRouteBackendTimeout,
 		features.SupportGatewayHTTPListenerIsolation,
 		features.SupportHTTPRouteParentRefPort,
 		// BackendTLSPolicy: Varnish 9.0 does not expose a backend API field for

--- a/conformance/conformance_test.go
+++ b/conformance/conformance_test.go
@@ -39,6 +39,7 @@ func TestConformance(t *testing.T) {
 		features.SupportHTTPRouteHostRewrite,
 		features.SupportHTTPRoutePathRewrite,
 		features.SupportHTTPRouteBackendTimeout,
+		features.SupportHTTPRouteRequestTimeout,
 		features.SupportGatewayHTTPListenerIsolation,
 		features.SupportHTTPRouteParentRefPort,
 		// BackendTLSPolicy: Varnish 9.0 does not expose a backend API field for

--- a/docs/reference/httproute-timeouts.md
+++ b/docs/reference/httproute-timeouts.md
@@ -24,6 +24,17 @@ spec:
 
 A route whose backend exceeds the timeout returns **504 Gateway Timeout**.
 
+## `request` and `backendRequest`
+
+| Field | Gateway API scope | Varnish behaviour |
+|---|---|---|
+| `backendRequest` | Gateway sends request headers → complete response received | `first_byte_timeout` + `between_bytes_timeout` |
+| `request` | Client request received → response fully sent | Same as `backendRequest` |
+
+Varnish has no total-request timeout, so `request` is applied as an alias for
+`backendRequest`. When both are set the tighter value wins — normally
+`backendRequest`, since the spec requires it to be no larger than `request`.
+
 ## How it maps to Varnish
 
 Varnish backends are pooled by `address:port`, so they cannot carry per-route
@@ -46,6 +57,11 @@ reason in `vcl_backend_error`, so a refused connection on a route with
 `backendRequest` set also returns 504 rather than 503. Routes without a timeout
 are unaffected and keep 503.
 
+**The clock starts at the backend fetch.** `request` is documented by Gateway API
+as covering the whole client request-response cycle. Varnish has no equivalent
+cap, so time spent reading the client request body or streaming the response back
+to a slow client is not counted, and there is no bound on total request duration.
+
 **Connect time is not bounded.** The timeout governs waiting for response bytes.
 Establishing the TCP connection is governed by varnishd's `connect_timeout`
 (3.5s by default), so an unreachable pod can take longer than `backendRequest`
@@ -64,7 +80,8 @@ headers are sent.
 **`0s` falls back to varnishd defaults.** Gateway API defines `0s` as "disable
 the timeout". Varnish always applies `first_byte_timeout` /
 `between_bytes_timeout`, so a disabled route inherits the global varnishd values
-(60s each by default) rather than running unbounded.
+(60s each by default) rather than running unbounded. Setting only one of the two
+fields to `0s` leaves the other in force.
 
 **No retries.** A timed-out fetch fails immediately; Varnish only retries when
 VCL calls `return (retry)`.

--- a/docs/reference/httproute-timeouts.md
+++ b/docs/reference/httproute-timeouts.md
@@ -28,7 +28,7 @@ A route whose backend exceeds the timeout returns **504 Gateway Timeout**.
 
 | Field | Gateway API scope | Varnish behaviour |
 |---|---|---|
-| `backendRequest` | Gateway sends request headers → complete response received | `first_byte_timeout` + `between_bytes_timeout` |
+| `backendRequest` | Gateway sends request headers → complete response received | `connect_timeout` + `first_byte_timeout` + `between_bytes_timeout` |
 | `request` | Client request received → response fully sent | Same as `backendRequest` |
 
 `request` is applied as an alias for `backendRequest`. When both are set the
@@ -42,9 +42,17 @@ timeouts. Ghost bridges the value on the matched route to the fetch instead:
 
 ```
 routing.json → ghost.json → ghost sets X-Ghost-Timeout on the request
-  → vcl_backend_fetch sets bereq.first_byte_timeout + bereq.between_bytes_timeout
+  → vcl_backend_fetch sets bereq.connect_timeout + bereq.first_byte_timeout
+    + bereq.between_bytes_timeout
   → vcl_backend_error reports 504 instead of 503
 ```
+
+All three are set to the same value, so the route's budget bounds establishing the
+connection as well as waiting for bytes. Gateway API scopes `backendRequest` to
+after request headers are sent, but the bound users actually want is their own
+wall-clock wait. A route with a tight timeout to an off-cluster backend
+(ExternalName, or one using TLS) must complete the TCP and TLS handshake inside
+that budget.
 
 ## Caveats
 
@@ -59,12 +67,6 @@ Varnish has neither bound — the clock necessarily starts at the backend fetch,
 time spent reading the client request body or streaming back to a slow client is
 not counted.
 
-**Connect time is not bounded.** The timeout governs waiting for response bytes.
-Establishing the TCP connection is governed by varnishd's `connect_timeout`
-(3.5s by default), so an unreachable pod can take longer than `backendRequest`
-to fail. Lower it globally via
-[varnishd arguments](varnishd-args.md) if that matters.
-
 **Streaming responses are cut mid-body.** `between_bytes_timeout` bounds every
 gap between response body bytes, not the total elapsed time, so a long-lived SSE
 or streaming response on a route with a short `backendRequest` is terminated —
@@ -72,10 +74,10 @@ and once headers are delivered the 504 flip no longer applies, so the client see
 a truncated 200. Do not set `backendRequest` on streaming routes.
 
 **`0s` falls back to varnishd defaults.** Gateway API defines `0s` as "disable
-the timeout". Varnish always applies `first_byte_timeout` /
-`between_bytes_timeout`, so a disabled route inherits the global varnishd values
-(60s each by default) rather than running unbounded. Setting only one of the two
-fields to `0s` leaves the other in force.
+the timeout". Varnish always applies its fetch timeouts, so a disabled route
+inherits the global varnishd values (`connect_timeout` 3.5s, `first_byte_timeout`
+and `between_bytes_timeout` 60s each) rather than running unbounded. Setting only
+one of the two fields to `0s` leaves the other in force.
 
 **No retries.** A timed-out fetch fails immediately; Varnish only retries when
 VCL calls `return (retry)`.

--- a/docs/reference/httproute-timeouts.md
+++ b/docs/reference/httproute-timeouts.md
@@ -1,0 +1,93 @@
+# HTTPRoute Timeouts
+
+`HTTPRouteRule.timeouts` bounds how long the gateway waits on a backend.
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: api-route
+spec:
+  parentRefs:
+    - name: my-gateway
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /slow-api
+      backendRefs:
+        - name: api-service
+          port: 8080
+      timeouts:
+        backendRequest: 5s
+```
+
+A route whose backend exceeds the timeout returns **504 Gateway Timeout**.
+
+## How it maps to Varnish
+
+Varnish backends are pooled by `address:port`, so they cannot carry per-route
+timeouts. Ghost bridges the value on the matched route to the fetch instead:
+
+```
+routing.json → ghost.json → ghost sets X-Ghost-Timeout on the request
+  → vcl_backend_fetch sets bereq.first_byte_timeout + bereq.between_bytes_timeout
+  → vcl_backend_error reports 504 instead of 503
+```
+
+`backendRequest` is scoped by Gateway API to the *complete* response, but Varnish
+has no total-fetch cap. `between_bytes_timeout` is the closest equivalent: it
+bounds the gap between response body bytes, not the total elapsed time.
+
+## Caveats
+
+**Any fetch failure on a timeout route reports 504.** Varnish exposes no failure
+reason in `vcl_backend_error`, so a refused connection on a route with
+`backendRequest` set also returns 504 rather than 503. Routes without a timeout
+are unaffected and keep 503.
+
+**Connect time is not bounded.** The timeout governs waiting for response bytes.
+Establishing the TCP connection is governed by varnishd's `connect_timeout`
+(3.5s by default), so an unreachable pod can take longer than `backendRequest`
+to fail. Lower it globally via
+[varnishd arguments](varnishd-args.md) if that matters.
+
+**Streaming responses are cut.** `between_bytes_timeout` applies to every gap in
+the response body, so a long-lived SSE or streaming response on a route with a
+short `backendRequest` will be terminated. Do not set `backendRequest` on
+streaming routes.
+
+**Once headers are delivered, the status cannot change.** A timeout that fires
+mid-body truncates the response — the 504 flip only applies before response
+headers are sent.
+
+**`0s` falls back to varnishd defaults.** Gateway API defines `0s` as "disable
+the timeout". Varnish always applies `first_byte_timeout` /
+`between_bytes_timeout`, so a disabled route inherits the global varnishd values
+(60s each by default) rather than running unbounded.
+
+**No retries.** A timed-out fetch fails immediately; Varnish only retries when
+VCL calls `return (retry)`.
+
+## Interaction with user VCL
+
+The 504 flip lives in the gateway postamble, which is concatenated *after* user
+VCL. A user-supplied `vcl_backend_error` that ends with `return (deliver)`
+terminates VCL execution before the postamble runs, and the response keeps
+Varnish's 503. Branch on `bereq.http.X-Ghost-Timeout` if you need custom
+handling for timed-out routes:
+
+```vcl
+sub vcl_backend_error {
+    if (bereq.http.X-Ghost-Timeout) {
+        set beresp.status = 504;
+        set beresp.http.Content-Type = "application/json";
+        set beresp.body = {"{"error": "upstream timeout"}"};
+        return (deliver);
+    }
+}
+```
+
+`X-Ghost-Timeout` is stripped from client requests in `vcl_recv` before routing,
+so it cannot be spoofed. Like the cache policy headers, it stays on `bereq`
+through the fetch and is therefore visible to the backend.

--- a/docs/reference/httproute-timeouts.md
+++ b/docs/reference/httproute-timeouts.md
@@ -31,9 +31,9 @@ A route whose backend exceeds the timeout returns **504 Gateway Timeout**.
 | `backendRequest` | Gateway sends request headers → complete response received | `first_byte_timeout` + `between_bytes_timeout` |
 | `request` | Client request received → response fully sent | Same as `backendRequest` |
 
-Varnish has no total-request timeout, so `request` is applied as an alias for
-`backendRequest`. When both are set the tighter value wins — normally
-`backendRequest`, since the spec requires it to be no larger than `request`.
+`request` is applied as an alias for `backendRequest`. When both are set the
+tighter value wins — normally `backendRequest`, since the spec requires it to be
+no larger than `request`.
 
 ## How it maps to Varnish
 
@@ -46,10 +46,6 @@ routing.json → ghost.json → ghost sets X-Ghost-Timeout on the request
   → vcl_backend_error reports 504 instead of 503
 ```
 
-`backendRequest` is scoped by Gateway API to the *complete* response, but Varnish
-has no total-fetch cap. `between_bytes_timeout` is the closest equivalent: it
-bounds the gap between response body bytes, not the total elapsed time.
-
 ## Caveats
 
 **Any fetch failure on a timeout route reports 504.** Varnish exposes no failure
@@ -57,10 +53,11 @@ reason in `vcl_backend_error`, so a refused connection on a route with
 `backendRequest` set also returns 504 rather than 503. Routes without a timeout
 are unaffected and keep 503.
 
-**The clock starts at the backend fetch.** `request` is documented by Gateway API
-as covering the whole client request-response cycle. Varnish has no equivalent
-cap, so time spent reading the client request body or streaming the response back
-to a slow client is not counted, and there is no bound on total request duration.
+**There is no total-request cap.** Gateway API scopes `request` to the whole
+client request-response cycle and `backendRequest` to the complete response, but
+Varnish has neither bound — the clock necessarily starts at the backend fetch, and
+time spent reading the client request body or streaming back to a slow client is
+not counted.
 
 **Connect time is not bounded.** The timeout governs waiting for response bytes.
 Establishing the TCP connection is governed by varnishd's `connect_timeout`
@@ -68,14 +65,11 @@ Establishing the TCP connection is governed by varnishd's `connect_timeout`
 to fail. Lower it globally via
 [varnishd arguments](varnishd-args.md) if that matters.
 
-**Streaming responses are cut.** `between_bytes_timeout` applies to every gap in
-the response body, so a long-lived SSE or streaming response on a route with a
-short `backendRequest` will be terminated. Do not set `backendRequest` on
-streaming routes.
-
-**Once headers are delivered, the status cannot change.** A timeout that fires
-mid-body truncates the response — the 504 flip only applies before response
-headers are sent.
+**Streaming responses are cut mid-body.** `between_bytes_timeout` bounds every
+gap between response body bytes, not the total elapsed time, so a long-lived SSE
+or streaming response on a route with a short `backendRequest` is terminated —
+and once headers are delivered the 504 flip no longer applies, so the client sees
+a truncated 200. Do not set `backendRequest` on streaming routes.
 
 **`0s` falls back to varnishd defaults.** Gateway API defines `0s` as "disable
 the timeout". Varnish always applies `first_byte_timeout` /

--- a/ghost/src/config.rs
+++ b/ghost/src/config.rs
@@ -228,6 +228,10 @@ pub struct Route {
     /// Cache policy from VarnishCachePolicy. None means pass-through (no caching).
     #[serde(default)]
     pub cache_policy: Option<CachePolicy>,
+    /// HTTPRoute `timeouts.backendRequest` in milliseconds. Absent means no
+    /// per-route timeout — varnishd's global defaults apply.
+    #[serde(default)]
+    pub backend_timeout_ms: Option<u32>,
 }
 
 /// All routing rules for a single hostname (e.g., "api.example.com").

--- a/ghost/src/config.rs
+++ b/ghost/src/config.rs
@@ -228,8 +228,7 @@ pub struct Route {
     /// Cache policy from VarnishCachePolicy. None means pass-through (no caching).
     #[serde(default)]
     pub cache_policy: Option<CachePolicy>,
-    /// HTTPRoute `timeouts.backendRequest` in milliseconds. Absent means no
-    /// per-route timeout — varnishd's global defaults apply.
+    /// Effective route timeout in milliseconds. Absent means varnishd's defaults.
     #[serde(default)]
     pub backend_timeout_ms: Option<u32>,
 }

--- a/ghost/src/director.rs
+++ b/ghost/src/director.rs
@@ -202,6 +202,9 @@ pub struct RouteEntry {
     pub cache_policy: Option<crate::config::CachePolicy>,
     /// Pre-compiled bypass header rules (extracted from cache_policy at config load time).
     pub bypass_headers: Vec<BypassHeaderCompiled>,
+    /// HTTPRoute `timeouts.backendRequest` in milliseconds, bridged to bereq via
+    /// the X-Ghost-Timeout header. None means varnishd's global defaults apply.
+    pub backend_timeout_ms: Option<u32>,
 }
 
 /// Map of vhost directors for two-tier routing
@@ -348,6 +351,7 @@ pub fn build_vhost_directors(
                 rule_index: route.rule_index,
                 cache_policy: route.cache_policy.clone(),
                 bypass_headers,
+                backend_timeout_ms: route.backend_timeout_ms,
             });
         }
 
@@ -377,6 +381,7 @@ pub fn build_vhost_directors(
                 rule_index: i32::MAX,
                 cache_policy: None,
                 bypass_headers: Vec::new(),
+                backend_timeout_ms: None,
             });
         }
 

--- a/ghost/src/director.rs
+++ b/ghost/src/director.rs
@@ -202,8 +202,7 @@ pub struct RouteEntry {
     pub cache_policy: Option<crate::config::CachePolicy>,
     /// Pre-compiled bypass header rules (extracted from cache_policy at config load time).
     pub bypass_headers: Vec<BypassHeaderCompiled>,
-    /// HTTPRoute `timeouts.backendRequest` in milliseconds, bridged to bereq via
-    /// the X-Ghost-Timeout header. None means varnishd's global defaults apply.
+    /// Effective route timeout in milliseconds, bridged to bereq via X-Ghost-Timeout.
     pub backend_timeout_ms: Option<u32>,
 }
 

--- a/ghost/src/vhost_director.rs
+++ b/ghost/src/vhost_director.rs
@@ -32,6 +32,7 @@ pub struct RouteMatchResult<'a> {
     pub route_name: Option<&'a str>,
     pub cache_policy: Option<&'a crate::config::CachePolicy>,
     pub bypass_headers: &'a [crate::director::BypassHeaderCompiled],
+    pub backend_timeout_ms: Option<u32>,
 }
 
 /// Result returned by route_request to the caller (recv/resolve).
@@ -387,6 +388,16 @@ impl VhostDirector {
         // Determine cache behavior from policy
         let pass = apply_cache_policy_headers(http, &match_result, &query_string_owned);
 
+        // Per-route backend timeout (HTTPRoute timeouts.backendRequest), bridged
+        // to bereq. vcl_backend_fetch turns this into first_byte_timeout /
+        // between_bytes_timeout, and the postamble vcl_backend_error uses its
+        // presence to report 504 rather than Varnish's default 503.
+        // Must unset first since set_header() appends a header slot.
+        if let Some(ms) = match_result.backend_timeout_ms {
+            http.unset_header("X-Ghost-Timeout");
+            let _ = http.set_header("X-Ghost-Timeout", &format!("{}ms", ms));
+        }
+
         // Select backend using two-level weighted random:
         // Level 1: pick a group by weight
         // Level 2: pick a random pod within the selected group
@@ -521,6 +532,7 @@ fn match_routes<'a>(
             route_name: route.route_name.as_deref(),
             cache_policy: route.cache_policy.as_ref(),
             bypass_headers: &route.bypass_headers,
+            backend_timeout_ms: route.backend_timeout_ms,
         });
     }
 
@@ -1155,6 +1167,7 @@ mod tests {
             rule_index: 0,
             cache_policy: None,
             bypass_headers: Vec::new(),
+            backend_timeout_ms: None,
         }];
 
         // This test doesn't use HttpHeaders, so we can't fully test it here
@@ -1182,6 +1195,7 @@ mod tests {
             rule_index: 0,
             cache_policy: None,
             bypass_headers: Vec::new(),
+            backend_timeout_ms: None,
         }];
 
         // Verify route structure
@@ -1212,6 +1226,7 @@ mod tests {
                 rule_index: 0,
                 cache_policy: None,
                 bypass_headers: Vec::new(),
+                backend_timeout_ms: None,
             }],
             backend_pool.clone(),
             None,
@@ -1311,6 +1326,7 @@ mod tests {
             route_name: Some("default/my-route"),
             cache_policy: None,
             bypass_headers: &[],
+            backend_timeout_ms: None,
         };
 
         assert_eq!(result.backend_groups.len(), 1);

--- a/ghost/tests/test_backend_timeout.vtc
+++ b/ghost/tests/test_backend_timeout.vtc
@@ -1,0 +1,151 @@
+varnishtest "per-route backendRequest timeout maps to 504"
+
+# Slow backend: holds the connection open well past the route's 500ms timeout.
+# Deliberately never sends a response — writing one after Varnish has already
+# given up and closed the backend connection races with the test harness.
+server s_slow {
+    rxreq
+    delay 2
+} -start
+
+# Fast backend on a route that also carries a timeout: must not be affected.
+server s_fast {
+    rxreq
+    txresp -body "on-time"
+} -start
+
+# Slow backend on a route with NO timeout configured: proves the 504 flip is
+# scoped to timeout routes and does not turn every fetch failure into a 504.
+# Serves both the c_untimed and c_spoof requests.
+server s_untimed -repeat 2 {
+    rxreq
+    delay 1
+    txresp -body "untimed"
+} -start
+
+shell {
+    cat > ${tmpdir}/ghost.json <<EOF
+{
+    "version": 2,
+    "vhosts": {
+        "api.example.com": {
+            "routes": [
+                {
+                    "path_match": {"type": "PathPrefix", "value": "/slow"},
+                    "backend_groups": [
+                        {"weight": 100, "backends": [
+                            {"address": "${s_slow_addr}", "port": ${s_slow_port}}
+                        ]}
+                    ],
+                    "backend_timeout_ms": 500,
+                    "priority": 10300
+                },
+                {
+                    "path_match": {"type": "PathPrefix", "value": "/fast"},
+                    "backend_groups": [
+                        {"weight": 100, "backends": [
+                            {"address": "${s_fast_addr}", "port": ${s_fast_port}}
+                        ]}
+                    ],
+                    "backend_timeout_ms": 500,
+                    "priority": 10300
+                },
+                {
+                    "path_match": {"type": "PathPrefix", "value": "/untimed"},
+                    "backend_groups": [
+                        {"weight": 100, "backends": [
+                            {"address": "${s_untimed_addr}", "port": ${s_untimed_port}}
+                        ]}
+                    ],
+                    "priority": 10300
+                }
+            ]
+        }
+    }
+}
+EOF
+}
+
+# Mirrors the generated preamble/postamble: the timeout bridge lives in
+# vcl_backend_fetch and the 503 -> 504 flip in vcl_backend_error.
+# Global first_byte_timeout is raised so the /untimed route is governed by the
+# route config (i.e. no timeout) rather than by a short varnishd default.
+varnish v1 -arg "-p thread_pool_stack=160k" -arg "-p first_byte_timeout=10" -vcl {
+    import ghost from "${vmod}";
+    import std;
+
+    backend dummy none;
+
+    sub vcl_init {
+        ghost.init("${tmpdir}/ghost.json");
+        new router = ghost.ghost_backend();
+    }
+
+    sub vcl_recv {
+        unset req.http.X-Ghost-Timeout;
+        if (req.url == "/.varnish-ghost/reload") {
+            if (router.reload()) {
+                return (synth(200, "OK"));
+            } else {
+                return (synth(500, "Reload failed"));
+            }
+        }
+        set req.backend_hint = router.recv();
+        return (pass);
+    }
+
+    sub vcl_backend_fetch {
+        if (bereq.http.X-Ghost-Timeout) {
+            set bereq.first_byte_timeout = std.duration(bereq.http.X-Ghost-Timeout, 60s);
+            set bereq.between_bytes_timeout = std.duration(bereq.http.X-Ghost-Timeout, 60s);
+        }
+    }
+
+    sub vcl_backend_error {
+        if (bereq.http.X-Ghost-Timeout) {
+            set beresp.status = 504;
+            set beresp.reason = "Gateway Timeout";
+            set beresp.ttl = 0s;
+        }
+    }
+} -start
+
+client c_reload {
+    txreq -url "/.varnish-ghost/reload"
+    rxresp
+    expect resp.status == 200
+} -run
+
+# Backend exceeds the route timeout -> 504, not 503.
+client c_slow {
+    txreq -url "/slow" -hdr "Host: api.example.com"
+    rxresp
+    expect resp.status == 504
+    expect resp.reason == "Gateway Timeout"
+} -run
+
+# Same timeout, backend responds in time -> untouched.
+client c_fast {
+    txreq -url "/fast" -hdr "Host: api.example.com"
+    rxresp
+    expect resp.status == 200
+    expect resp.body == "on-time"
+} -run
+
+# No timeout on the route -> slow backend still succeeds, and X-Ghost-Timeout
+# never reaches the backend.
+client c_untimed {
+    txreq -url "/untimed" -hdr "Host: api.example.com"
+    rxresp
+    expect resp.status == 200
+    expect resp.body == "untimed"
+} -run
+
+# A client-supplied X-Ghost-Timeout must not be able to impose a timeout on a
+# route that has none (the preamble strips it in vcl_recv).
+client c_spoof {
+    txreq -url "/untimed" -hdr "Host: api.example.com" -hdr "X-Ghost-Timeout: 1ms"
+    rxresp
+    expect resp.status == 200
+    expect resp.body == "untimed"
+} -run

--- a/internal/ghost/config.go
+++ b/internal/ghost/config.go
@@ -198,9 +198,7 @@ type Route struct {
 	RuleIndex   int               `json:"rule_index"`             // Original rule ordering for tiebreaking
 	CachePolicy *CachePolicy      `json:"cache_policy,omitempty"` // Caching behavior from VarnishCachePolicy
 	BackendTLS  *BackendTLS       `json:"backend_tls,omitempty"`  // TLS config from BackendTLSPolicy
-	// BackendTimeoutMs is the HTTPRoute rule's timeouts.backendRequest in
-	// milliseconds. 0 (absent) means no per-route timeout: varnishd's global
-	// first_byte_timeout/between_bytes_timeout apply.
+	// BackendTimeoutMs is the effective rule timeout in ms; 0 means unset.
 	BackendTimeoutMs int `json:"backend_timeout_ms,omitempty"`
 	// ExternalProxy is set when the route's backendRef points to a Service of
 	// type ExternalName. The chaperone passes this through to ghost.json
@@ -234,8 +232,7 @@ type RouteBackends struct {
 	Priority      int               `json:"priority"`
 	RuleIndex     int               `json:"rule_index"`
 	CachePolicy   *CachePolicy      `json:"cache_policy,omitempty"` // Caching behavior from VarnishCachePolicy
-	// BackendTimeoutMs mirrors Route.BackendTimeoutMs. Passed through to ghost,
-	// which bridges it to bereq via the X-Ghost-Timeout header.
+	// BackendTimeoutMs mirrors Route.BackendTimeoutMs.
 	BackendTimeoutMs int `json:"backend_timeout_ms,omitempty"`
 }
 

--- a/internal/ghost/config.go
+++ b/internal/ghost/config.go
@@ -198,6 +198,10 @@ type Route struct {
 	RuleIndex   int               `json:"rule_index"`             // Original rule ordering for tiebreaking
 	CachePolicy *CachePolicy      `json:"cache_policy,omitempty"` // Caching behavior from VarnishCachePolicy
 	BackendTLS  *BackendTLS       `json:"backend_tls,omitempty"`  // TLS config from BackendTLSPolicy
+	// BackendTimeoutMs is the HTTPRoute rule's timeouts.backendRequest in
+	// milliseconds. 0 (absent) means no per-route timeout: varnishd's global
+	// first_byte_timeout/between_bytes_timeout apply.
+	BackendTimeoutMs int `json:"backend_timeout_ms,omitempty"`
 	// ExternalProxy is set when the route's backendRef points to a Service of
 	// type ExternalName. The chaperone passes this through to ghost.json
 	// without performing EndpointSlice lookup.
@@ -230,6 +234,9 @@ type RouteBackends struct {
 	Priority      int               `json:"priority"`
 	RuleIndex     int               `json:"rule_index"`
 	CachePolicy   *CachePolicy      `json:"cache_policy,omitempty"` // Caching behavior from VarnishCachePolicy
+	// BackendTimeoutMs mirrors Route.BackendTimeoutMs. Passed through to ghost,
+	// which bridges it to bereq via the X-Ghost-Timeout header.
+	BackendTimeoutMs int `json:"backend_timeout_ms,omitempty"`
 }
 
 // VHostConfig represents a virtual host with path-based routing in ghost.json.

--- a/internal/ghost/config.go
+++ b/internal/ghost/config.go
@@ -195,10 +195,11 @@ type Route struct {
 	RouteName   string            `json:"route_name,omitempty"` // HTTPRoute namespace/name
 	RuleName    string            `json:"rule_name,omitempty"`  // HTTPRouteRule name for per-rule VCP targeting
 	Priority    int               `json:"priority"`
-	RuleIndex   int               `json:"rule_index"`                   // Original rule ordering for tiebreaking
-	CachePolicy *CachePolicy      `json:"cache_policy,omitempty"`       // Caching behavior from VarnishCachePolicy
-	BackendTLS  *BackendTLS       `json:"backend_tls,omitempty"`        // TLS config from BackendTLSPolicy
-	TimeoutMs   int               `json:"backend_timeout_ms,omitempty"` // Effective rule timeout in ms; 0 means unset
+	RuleIndex   int               `json:"rule_index"`             // Original rule ordering for tiebreaking
+	CachePolicy *CachePolicy      `json:"cache_policy,omitempty"` // Caching behavior from VarnishCachePolicy
+	BackendTLS  *BackendTLS       `json:"backend_tls,omitempty"`  // TLS config from BackendTLSPolicy
+	// BackendTimeoutMs is the effective rule timeout in ms; 0 means unset.
+	BackendTimeoutMs int `json:"backend_timeout_ms,omitempty"`
 	// ExternalProxy is set when the route's backendRef points to a Service of
 	// type ExternalName. The chaperone passes this through to ghost.json
 	// without performing EndpointSlice lookup.
@@ -230,8 +231,9 @@ type RouteBackends struct {
 	RouteName     string            `json:"route_name,omitempty"` // HTTPRoute namespace/name
 	Priority      int               `json:"priority"`
 	RuleIndex     int               `json:"rule_index"`
-	CachePolicy   *CachePolicy      `json:"cache_policy,omitempty"`       // Caching behavior from VarnishCachePolicy
-	TimeoutMs     int               `json:"backend_timeout_ms,omitempty"` // Effective rule timeout in ms; 0 means unset
+	CachePolicy   *CachePolicy      `json:"cache_policy,omitempty"` // Caching behavior from VarnishCachePolicy
+	// BackendTimeoutMs mirrors Route.BackendTimeoutMs.
+	BackendTimeoutMs int `json:"backend_timeout_ms,omitempty"`
 }
 
 // VHostConfig represents a virtual host with path-based routing in ghost.json.

--- a/internal/ghost/config.go
+++ b/internal/ghost/config.go
@@ -195,11 +195,10 @@ type Route struct {
 	RouteName   string            `json:"route_name,omitempty"` // HTTPRoute namespace/name
 	RuleName    string            `json:"rule_name,omitempty"`  // HTTPRouteRule name for per-rule VCP targeting
 	Priority    int               `json:"priority"`
-	RuleIndex   int               `json:"rule_index"`             // Original rule ordering for tiebreaking
-	CachePolicy *CachePolicy      `json:"cache_policy,omitempty"` // Caching behavior from VarnishCachePolicy
-	BackendTLS  *BackendTLS       `json:"backend_tls,omitempty"`  // TLS config from BackendTLSPolicy
-	// BackendTimeoutMs is the effective rule timeout in ms; 0 means unset.
-	BackendTimeoutMs int `json:"backend_timeout_ms,omitempty"`
+	RuleIndex   int               `json:"rule_index"`                   // Original rule ordering for tiebreaking
+	CachePolicy *CachePolicy      `json:"cache_policy,omitempty"`       // Caching behavior from VarnishCachePolicy
+	BackendTLS  *BackendTLS       `json:"backend_tls,omitempty"`        // TLS config from BackendTLSPolicy
+	TimeoutMs   int               `json:"backend_timeout_ms,omitempty"` // Effective rule timeout in ms; 0 means unset
 	// ExternalProxy is set when the route's backendRef points to a Service of
 	// type ExternalName. The chaperone passes this through to ghost.json
 	// without performing EndpointSlice lookup.
@@ -231,9 +230,8 @@ type RouteBackends struct {
 	RouteName     string            `json:"route_name,omitempty"` // HTTPRoute namespace/name
 	Priority      int               `json:"priority"`
 	RuleIndex     int               `json:"rule_index"`
-	CachePolicy   *CachePolicy      `json:"cache_policy,omitempty"` // Caching behavior from VarnishCachePolicy
-	// BackendTimeoutMs mirrors Route.BackendTimeoutMs.
-	BackendTimeoutMs int `json:"backend_timeout_ms,omitempty"`
+	CachePolicy   *CachePolicy      `json:"cache_policy,omitempty"`       // Caching behavior from VarnishCachePolicy
+	TimeoutMs     int               `json:"backend_timeout_ms,omitempty"` // Effective rule timeout in ms; 0 means unset
 }
 
 // VHostConfig represents a virtual host with path-based routing in ghost.json.

--- a/internal/ghost/generator.go
+++ b/internal/ghost/generator.go
@@ -116,9 +116,8 @@ func mergeRoutesByMatchCriteria(routes []Route, endpoints ServiceEndpoints) []Ro
 		cachePolicy string // JSON serialization of CachePolicy
 		priority    int
 		ruleIndex   int
-		// Keyed for the same reason as cachePolicy: it is a per-route attribute
-		// that RouteBackends takes from the first route in the group, so merging
-		// routes with different timeouts would silently drop one.
+		// In the key because RouteBackends takes it from the first route in the
+		// group — merging routes with different timeouts would silently drop one.
 		backendTimeoutMs int
 	}
 

--- a/internal/ghost/generator.go
+++ b/internal/ghost/generator.go
@@ -116,6 +116,10 @@ func mergeRoutesByMatchCriteria(routes []Route, endpoints ServiceEndpoints) []Ro
 		cachePolicy string // JSON serialization of CachePolicy
 		priority    int
 		ruleIndex   int
+		// Keyed for the same reason as cachePolicy: it is a per-route attribute
+		// that RouteBackends takes from the first route in the group, so merging
+		// routes with different timeouts would silently drop one.
+		backendTimeoutMs int
 	}
 
 	// NOTE: BackendTLS is intentionally NOT part of the merge key. Each BackendGroup
@@ -136,6 +140,8 @@ func mergeRoutesByMatchCriteria(routes []Route, endpoints ServiceEndpoints) []Ro
 			cachePolicy: serializeCachePolicy(route.CachePolicy),
 			priority:    route.Priority,
 			ruleIndex:   route.RuleIndex,
+
+			backendTimeoutMs: route.BackendTimeoutMs,
 		}
 		grouped[key] = append(grouped[key], route)
 	}
@@ -166,6 +172,8 @@ func mergeRoutesByMatchCriteria(routes []Route, endpoints ServiceEndpoints) []Ro
 			Priority:      key.priority,
 			RuleIndex:     key.ruleIndex,
 			CachePolicy:   firstRoute.CachePolicy,
+
+			BackendTimeoutMs: key.backendTimeoutMs,
 		})
 	}
 

--- a/internal/ghost/generator.go
+++ b/internal/ghost/generator.go
@@ -118,7 +118,7 @@ func mergeRoutesByMatchCriteria(routes []Route, endpoints ServiceEndpoints) []Ro
 		ruleIndex   int
 		// In the key because RouteBackends takes it from the first route in the
 		// group — merging routes with different timeouts would silently drop one.
-		backendTimeoutMs int
+		timeoutMs int
 	}
 
 	// NOTE: BackendTLS is intentionally NOT part of the merge key. Each BackendGroup
@@ -139,8 +139,7 @@ func mergeRoutesByMatchCriteria(routes []Route, endpoints ServiceEndpoints) []Ro
 			cachePolicy: serializeCachePolicy(route.CachePolicy),
 			priority:    route.Priority,
 			ruleIndex:   route.RuleIndex,
-
-			backendTimeoutMs: route.BackendTimeoutMs,
+			timeoutMs:   route.TimeoutMs,
 		}
 		grouped[key] = append(grouped[key], route)
 	}
@@ -171,8 +170,7 @@ func mergeRoutesByMatchCriteria(routes []Route, endpoints ServiceEndpoints) []Ro
 			Priority:      key.priority,
 			RuleIndex:     key.ruleIndex,
 			CachePolicy:   firstRoute.CachePolicy,
-
-			BackendTimeoutMs: key.backendTimeoutMs,
+			TimeoutMs:     key.timeoutMs,
 		})
 	}
 

--- a/internal/ghost/generator.go
+++ b/internal/ghost/generator.go
@@ -118,7 +118,7 @@ func mergeRoutesByMatchCriteria(routes []Route, endpoints ServiceEndpoints) []Ro
 		ruleIndex   int
 		// In the key because RouteBackends takes it from the first route in the
 		// group — merging routes with different timeouts would silently drop one.
-		timeoutMs int
+		backendTimeoutMs int
 	}
 
 	// NOTE: BackendTLS is intentionally NOT part of the merge key. Each BackendGroup
@@ -130,16 +130,16 @@ func mergeRoutesByMatchCriteria(routes []Route, endpoints ServiceEndpoints) []Ro
 	grouped := make(map[routeKey][]Route)
 	for _, route := range routes {
 		key := routeKey{
-			pathMatch:   serializePathMatch(route.PathMatch),
-			method:      serializeMethod(route.Method),
-			headers:     serializeHeaders(route.Headers),
-			queryParams: serializeQueryParams(route.QueryParams),
-			filters:     serializeFilters(route.Filters),
-			listeners:   serializeListeners(route.Listeners),
-			cachePolicy: serializeCachePolicy(route.CachePolicy),
-			priority:    route.Priority,
-			ruleIndex:   route.RuleIndex,
-			timeoutMs:   route.TimeoutMs,
+			pathMatch:        serializePathMatch(route.PathMatch),
+			method:           serializeMethod(route.Method),
+			headers:          serializeHeaders(route.Headers),
+			queryParams:      serializeQueryParams(route.QueryParams),
+			filters:          serializeFilters(route.Filters),
+			listeners:        serializeListeners(route.Listeners),
+			cachePolicy:      serializeCachePolicy(route.CachePolicy),
+			priority:         route.Priority,
+			ruleIndex:        route.RuleIndex,
+			backendTimeoutMs: route.BackendTimeoutMs,
 		}
 		grouped[key] = append(grouped[key], route)
 	}
@@ -159,18 +159,18 @@ func mergeRoutesByMatchCriteria(routes []Route, endpoints ServiceEndpoints) []Ro
 		// Use the first route's match criteria (all routes in group have identical criteria)
 		firstRoute := routeGroup[0]
 		result = append(result, RouteBackends{
-			PathMatch:     firstRoute.PathMatch,
-			Method:        firstRoute.Method,
-			Headers:       firstRoute.Headers,
-			QueryParams:   firstRoute.QueryParams,
-			Filters:       firstRoute.Filters,
-			BackendGroups: groups,
-			Listeners:     firstRoute.Listeners,
-			RouteName:     firstRoute.RouteName,
-			Priority:      key.priority,
-			RuleIndex:     key.ruleIndex,
-			CachePolicy:   firstRoute.CachePolicy,
-			TimeoutMs:     key.timeoutMs,
+			PathMatch:        firstRoute.PathMatch,
+			Method:           firstRoute.Method,
+			Headers:          firstRoute.Headers,
+			QueryParams:      firstRoute.QueryParams,
+			Filters:          firstRoute.Filters,
+			BackendGroups:    groups,
+			Listeners:        firstRoute.Listeners,
+			RouteName:        firstRoute.RouteName,
+			Priority:         key.priority,
+			RuleIndex:        key.ruleIndex,
+			CachePolicy:      firstRoute.CachePolicy,
+			BackendTimeoutMs: key.backendTimeoutMs,
 		})
 	}
 

--- a/internal/ghost/generator_test.go
+++ b/internal/ghost/generator_test.go
@@ -774,3 +774,69 @@ func TestBackendTLSMergesIntoWeightedGroups(t *testing.T) {
 		t.Errorf("expected weights {90,10}, got %v", weights)
 	}
 }
+
+func TestGenerateBackendTimeoutPassthrough(t *testing.T) {
+	// Two backendRefs in the same rule (identical match criteria and rule index)
+	// must merge into ONE route with two weighted groups, carrying the timeout.
+	routingConfig := &RoutingConfig{
+		Version: 2,
+		VHosts: map[string]VHostRouting{
+			"api.example.com": {
+				Routes: []Route{
+					{
+						PathMatch:        &PathMatch{Type: PathMatchPathPrefix, Value: "/timed"},
+						Service:          "api-v1",
+						Namespace:        "default",
+						Port:             8080,
+						Weight:           50,
+						Priority:         10300,
+						BackendTimeoutMs: 500,
+					},
+					{
+						PathMatch:        &PathMatch{Type: PathMatchPathPrefix, Value: "/timed"},
+						Service:          "api-v2",
+						Namespace:        "default",
+						Port:             8080,
+						Weight:           50,
+						Priority:         10300,
+						BackendTimeoutMs: 500,
+					},
+					{
+						PathMatch: &PathMatch{Type: PathMatchPathPrefix, Value: "/untimed"},
+						Service:   "api-v1",
+						Namespace: "default",
+						Port:      8080,
+						Weight:    100,
+						Priority:  10300,
+					},
+				},
+			},
+		},
+	}
+
+	endpoints := ServiceEndpoints{
+		"default/api-v1": {{IP: "10.0.0.1", Port: 8080}},
+		"default/api-v2": {{IP: "10.0.0.2", Port: 8080}},
+	}
+
+	config := Generate(routingConfig, endpoints)
+
+	byPath := make(map[string]RouteBackends)
+	for _, r := range config.VHosts["api.example.com"].Routes {
+		byPath[r.PathMatch.Value] = r
+	}
+	if len(byPath) != 2 {
+		t.Fatalf("expected 2 merged routes, got %d", len(byPath))
+	}
+
+	timed := byPath["/timed"]
+	if timed.BackendTimeoutMs != 500 {
+		t.Errorf("/timed: BackendTimeoutMs = %d, want 500", timed.BackendTimeoutMs)
+	}
+	if len(timed.BackendGroups) != 2 {
+		t.Errorf("/timed: expected 2 weighted groups, got %d", len(timed.BackendGroups))
+	}
+	if got := byPath["/untimed"].BackendTimeoutMs; got != 0 {
+		t.Errorf("/untimed: BackendTimeoutMs = %d, want 0", got)
+	}
+}

--- a/internal/ghost/generator_test.go
+++ b/internal/ghost/generator_test.go
@@ -784,22 +784,22 @@ func TestGenerateBackendTimeoutPassthrough(t *testing.T) {
 			"api.example.com": {
 				Routes: []Route{
 					{
-						PathMatch:        &PathMatch{Type: PathMatchPathPrefix, Value: "/timed"},
-						Service:          "api-v1",
-						Namespace:        "default",
-						Port:             8080,
-						Weight:           50,
-						Priority:         10300,
-						BackendTimeoutMs: 500,
+						PathMatch: &PathMatch{Type: PathMatchPathPrefix, Value: "/timed"},
+						Service:   "api-v1",
+						Namespace: "default",
+						Port:      8080,
+						Weight:    50,
+						Priority:  10300,
+						TimeoutMs: 500,
 					},
 					{
-						PathMatch:        &PathMatch{Type: PathMatchPathPrefix, Value: "/timed"},
-						Service:          "api-v2",
-						Namespace:        "default",
-						Port:             8080,
-						Weight:           50,
-						Priority:         10300,
-						BackendTimeoutMs: 500,
+						PathMatch: &PathMatch{Type: PathMatchPathPrefix, Value: "/timed"},
+						Service:   "api-v2",
+						Namespace: "default",
+						Port:      8080,
+						Weight:    50,
+						Priority:  10300,
+						TimeoutMs: 500,
 					},
 					{
 						PathMatch: &PathMatch{Type: PathMatchPathPrefix, Value: "/untimed"},
@@ -830,13 +830,13 @@ func TestGenerateBackendTimeoutPassthrough(t *testing.T) {
 	}
 
 	timed := byPath["/timed"]
-	if timed.BackendTimeoutMs != 500 {
-		t.Errorf("/timed: BackendTimeoutMs = %d, want 500", timed.BackendTimeoutMs)
+	if timed.TimeoutMs != 500 {
+		t.Errorf("/timed: TimeoutMs = %d, want 500", timed.TimeoutMs)
 	}
 	if len(timed.BackendGroups) != 2 {
 		t.Errorf("/timed: expected 2 weighted groups, got %d", len(timed.BackendGroups))
 	}
-	if got := byPath["/untimed"].BackendTimeoutMs; got != 0 {
-		t.Errorf("/untimed: BackendTimeoutMs = %d, want 0", got)
+	if got := byPath["/untimed"].TimeoutMs; got != 0 {
+		t.Errorf("/untimed: TimeoutMs = %d, want 0", got)
 	}
 }

--- a/internal/ghost/generator_test.go
+++ b/internal/ghost/generator_test.go
@@ -784,22 +784,22 @@ func TestGenerateBackendTimeoutPassthrough(t *testing.T) {
 			"api.example.com": {
 				Routes: []Route{
 					{
-						PathMatch: &PathMatch{Type: PathMatchPathPrefix, Value: "/timed"},
-						Service:   "api-v1",
-						Namespace: "default",
-						Port:      8080,
-						Weight:    50,
-						Priority:  10300,
-						TimeoutMs: 500,
+						PathMatch:        &PathMatch{Type: PathMatchPathPrefix, Value: "/timed"},
+						Service:          "api-v1",
+						Namespace:        "default",
+						Port:             8080,
+						Weight:           50,
+						Priority:         10300,
+						BackendTimeoutMs: 500,
 					},
 					{
-						PathMatch: &PathMatch{Type: PathMatchPathPrefix, Value: "/timed"},
-						Service:   "api-v2",
-						Namespace: "default",
-						Port:      8080,
-						Weight:    50,
-						Priority:  10300,
-						TimeoutMs: 500,
+						PathMatch:        &PathMatch{Type: PathMatchPathPrefix, Value: "/timed"},
+						Service:          "api-v2",
+						Namespace:        "default",
+						Port:             8080,
+						Weight:           50,
+						Priority:         10300,
+						BackendTimeoutMs: 500,
 					},
 					{
 						PathMatch: &PathMatch{Type: PathMatchPathPrefix, Value: "/untimed"},
@@ -830,13 +830,13 @@ func TestGenerateBackendTimeoutPassthrough(t *testing.T) {
 	}
 
 	timed := byPath["/timed"]
-	if timed.TimeoutMs != 500 {
-		t.Errorf("/timed: TimeoutMs = %d, want 500", timed.TimeoutMs)
+	if timed.BackendTimeoutMs != 500 {
+		t.Errorf("/timed: BackendTimeoutMs = %d, want 500", timed.BackendTimeoutMs)
 	}
 	if len(timed.BackendGroups) != 2 {
 		t.Errorf("/timed: expected 2 weighted groups, got %d", len(timed.BackendGroups))
 	}
-	if got := byPath["/untimed"].TimeoutMs; got != 0 {
-		t.Errorf("/untimed: TimeoutMs = %d, want 0", got)
+	if got := byPath["/untimed"].BackendTimeoutMs; got != 0 {
+		t.Errorf("/untimed: BackendTimeoutMs = %d, want 0", got)
 	}
 }

--- a/internal/vcl/generator.go
+++ b/internal/vcl/generator.go
@@ -179,19 +179,19 @@ func CollectHTTPRouteBackends(routes []gatewayv1.HTTPRoute, gateway *gatewayv1.G
 					// Handle filter-only routes with no backends (e.g., redirects with no matches)
 					if len(rule.BackendRefs) == 0 && filters != nil {
 						collectedRoutes = append(collectedRoutes, ghost.Route{
-							Hostname:         hostname,
-							PathMatch:        pathMatch,
-							Filters:          filters,
-							Service:          "",
-							Namespace:        routeNS,
-							Port:             0,
-							Weight:           0,
-							Listeners:        listeners,
-							RouteName:        routeName,
-							RuleName:         ruleName,
-							Priority:         CalculateRoutePriority(pathMatch, nil, nil, nil),
-							RuleIndex:        ruleIndex,
-							BackendTimeoutMs: timeoutMs,
+							Hostname:  hostname,
+							PathMatch: pathMatch,
+							Filters:   filters,
+							Service:   "",
+							Namespace: routeNS,
+							Port:      0,
+							Weight:    0,
+							Listeners: listeners,
+							RouteName: routeName,
+							RuleName:  ruleName,
+							Priority:  CalculateRoutePriority(pathMatch, nil, nil, nil),
+							RuleIndex: ruleIndex,
+							TimeoutMs: timeoutMs,
 						})
 					}
 
@@ -201,19 +201,19 @@ func CollectHTTPRouteBackends(routes []gatewayv1.HTTPRoute, gateway *gatewayv1.G
 					// If all backends were filtered, create a route with no backend (ghost returns 500)
 					if len(validNoMatchBackends) == 0 && len(rule.BackendRefs) > 0 {
 						collectedRoutes = append(collectedRoutes, ghost.Route{
-							Hostname:         hostname,
-							PathMatch:        pathMatch,
-							Filters:          filters,
-							Service:          "",
-							Namespace:        routeNS,
-							Port:             0,
-							Weight:           0,
-							Listeners:        listeners,
-							RouteName:        routeName,
-							RuleName:         ruleName,
-							Priority:         CalculateRoutePriority(pathMatch, nil, nil, nil),
-							RuleIndex:        ruleIndex,
-							BackendTimeoutMs: timeoutMs,
+							Hostname:  hostname,
+							PathMatch: pathMatch,
+							Filters:   filters,
+							Service:   "",
+							Namespace: routeNS,
+							Port:      0,
+							Weight:    0,
+							Listeners: listeners,
+							RouteName: routeName,
+							RuleName:  ruleName,
+							Priority:  CalculateRoutePriority(pathMatch, nil, nil, nil),
+							RuleIndex: ruleIndex,
+							TimeoutMs: timeoutMs,
 						})
 					}
 
@@ -243,20 +243,20 @@ func CollectHTTPRouteBackends(routes []gatewayv1.HTTPRoute, gateway *gatewayv1.G
 						}
 
 						collectedRoutes = append(collectedRoutes, ghost.Route{
-							Hostname:         hostname,
-							PathMatch:        pathMatch,
-							Filters:          filters,
-							Service:          string(backend.Name),
-							Namespace:        backendNS,
-							Port:             port,
-							PortName:         portName,
-							Weight:           weight,
-							Listeners:        listeners,
-							RouteName:        routeName,
-							RuleName:         ruleName,
-							Priority:         CalculateRoutePriority(pathMatch, nil, nil, nil),
-							RuleIndex:        ruleIndex,
-							BackendTimeoutMs: timeoutMs,
+							Hostname:  hostname,
+							PathMatch: pathMatch,
+							Filters:   filters,
+							Service:   string(backend.Name),
+							Namespace: backendNS,
+							Port:      port,
+							PortName:  portName,
+							Weight:    weight,
+							Listeners: listeners,
+							RouteName: routeName,
+							RuleName:  ruleName,
+							Priority:  CalculateRoutePriority(pathMatch, nil, nil, nil),
+							RuleIndex: ruleIndex,
+							TimeoutMs: timeoutMs,
 						})
 					}
 				} else {
@@ -349,22 +349,22 @@ func CollectHTTPRouteBackends(routes []gatewayv1.HTTPRoute, gateway *gatewayv1.G
 						if len(validBackendRefs) == 0 {
 							if filters != nil || len(rule.BackendRefs) > 0 {
 								collectedRoutes = append(collectedRoutes, ghost.Route{
-									Hostname:         hostname,
-									PathMatch:        pathMatch,
-									Method:           method,
-									Headers:          headers,
-									QueryParams:      queryParams,
-									Filters:          filters,
-									Service:          "",
-									Namespace:        routeNS,
-									Port:             0,
-									Weight:           0,
-									Listeners:        listeners,
-									RouteName:        routeName,
-									RuleName:         ruleName,
-									Priority:         CalculateRoutePriority(pathMatch, method, headers, queryParams),
-									RuleIndex:        ruleIndex,
-									BackendTimeoutMs: timeoutMs,
+									Hostname:    hostname,
+									PathMatch:   pathMatch,
+									Method:      method,
+									Headers:     headers,
+									QueryParams: queryParams,
+									Filters:     filters,
+									Service:     "",
+									Namespace:   routeNS,
+									Port:        0,
+									Weight:      0,
+									Listeners:   listeners,
+									RouteName:   routeName,
+									RuleName:    ruleName,
+									Priority:    CalculateRoutePriority(pathMatch, method, headers, queryParams),
+									RuleIndex:   ruleIndex,
+									TimeoutMs:   timeoutMs,
 								})
 							}
 						}
@@ -400,23 +400,23 @@ func CollectHTTPRouteBackends(routes []gatewayv1.HTTPRoute, gateway *gatewayv1.G
 							}
 
 							collectedRoutes = append(collectedRoutes, ghost.Route{
-								Hostname:         hostname,
-								PathMatch:        pathMatch,
-								Method:           method,
-								Headers:          headers,
-								QueryParams:      queryParams,
-								Filters:          filters,
-								Service:          string(backend.Name),
-								Namespace:        backendNS,
-								Port:             port,
-								PortName:         portName,
-								Weight:           weight,
-								Listeners:        listeners,
-								RouteName:        routeName,
-								RuleName:         ruleName,
-								Priority:         CalculateRoutePriority(pathMatch, method, headers, queryParams),
-								RuleIndex:        ruleIndex,
-								BackendTimeoutMs: timeoutMs,
+								Hostname:    hostname,
+								PathMatch:   pathMatch,
+								Method:      method,
+								Headers:     headers,
+								QueryParams: queryParams,
+								Filters:     filters,
+								Service:     string(backend.Name),
+								Namespace:   backendNS,
+								Port:        port,
+								PortName:    portName,
+								Weight:      weight,
+								Listeners:   listeners,
+								RouteName:   routeName,
+								RuleName:    ruleName,
+								Priority:    CalculateRoutePriority(pathMatch, method, headers, queryParams),
+								RuleIndex:   ruleIndex,
+								TimeoutMs:   timeoutMs,
 							})
 						}
 					}
@@ -452,18 +452,19 @@ func CollectHTTPRouteBackends(routes []gatewayv1.HTTPRoute, gateway *gatewayv1.G
 // routeTimeoutMs converts an HTTPRoute rule's timeouts into milliseconds for
 // routing.json. Returns 0 when no timeout applies, and 0 is serialized as absent.
 //
-// Both request and backendRequest map onto the same Varnish fetch timeouts, so
-// the tighter of the two wins. Gateway API scopes request to the entire client
-// request-response cycle, but Varnish has no total-request timeout — the clock
-// necessarily starts at the backend fetch, so request behaves as an alias for
-// backendRequest. Documented in docs/reference/httproute-timeouts.md.
+// request and backendRequest map onto the same Varnish fetch timeouts, so the
+// tighter of the two wins — the spec requires backendRequest <= request, but a
+// route that violates that must not end up with the looser bound. See
+// docs/reference/httproute-timeouts.md.
 func routeTimeoutMs(t *gatewayv1.HTTPRouteTimeouts) int {
 	if t == nil {
 		return 0
 	}
-	// The spec requires backendRequest <= request, but a route that violates
-	// that must not end up with the looser of the two bounds.
-	return minNonZeroMs(durationMs(t.Request), durationMs(t.BackendRequest))
+	ms := durationMs(t.Request)
+	if be := durationMs(t.BackendRequest); be != 0 && (ms == 0 || be < ms) {
+		ms = be
+	}
+	return ms
 }
 
 // durationMs parses a GEP-2257 duration into milliseconds. Returns 0 when unset,
@@ -483,17 +484,6 @@ func durationMs(d *gatewayv1.Duration) int {
 		return 0
 	}
 	return int(parsed.Milliseconds())
-}
-
-// minNonZeroMs returns the smaller of two timeouts, treating 0 as "unset".
-func minNonZeroMs(a, b int) int {
-	if a == 0 {
-		return b
-	}
-	if b == 0 {
-		return a
-	}
-	return min(a, b)
 }
 
 // filterValidBackends returns backend refs that have a valid Kind/Group and are not blocked.

--- a/internal/vcl/generator.go
+++ b/internal/vcl/generator.go
@@ -157,7 +157,7 @@ func CollectHTTPRouteBackends(routes []gatewayv1.HTTPRoute, gateway *gatewayv1.G
 
 				// Timeouts are per-rule, so every route entry generated from this
 				// rule carries the same value.
-				timeoutMs := routeTimeoutMs(rule.Timeouts)
+				backendTimeoutMs := routeBackendTimeoutMs(rule.Timeouts)
 
 				// Process each match in the rule
 				if len(rule.Matches) == 0 {
@@ -179,19 +179,19 @@ func CollectHTTPRouteBackends(routes []gatewayv1.HTTPRoute, gateway *gatewayv1.G
 					// Handle filter-only routes with no backends (e.g., redirects with no matches)
 					if len(rule.BackendRefs) == 0 && filters != nil {
 						collectedRoutes = append(collectedRoutes, ghost.Route{
-							Hostname:  hostname,
-							PathMatch: pathMatch,
-							Filters:   filters,
-							Service:   "",
-							Namespace: routeNS,
-							Port:      0,
-							Weight:    0,
-							Listeners: listeners,
-							RouteName: routeName,
-							RuleName:  ruleName,
-							Priority:  CalculateRoutePriority(pathMatch, nil, nil, nil),
-							RuleIndex: ruleIndex,
-							TimeoutMs: timeoutMs,
+							Hostname:         hostname,
+							PathMatch:        pathMatch,
+							Filters:          filters,
+							Service:          "",
+							Namespace:        routeNS,
+							Port:             0,
+							Weight:           0,
+							Listeners:        listeners,
+							RouteName:        routeName,
+							RuleName:         ruleName,
+							Priority:         CalculateRoutePriority(pathMatch, nil, nil, nil),
+							RuleIndex:        ruleIndex,
+							BackendTimeoutMs: backendTimeoutMs,
 						})
 					}
 
@@ -201,19 +201,19 @@ func CollectHTTPRouteBackends(routes []gatewayv1.HTTPRoute, gateway *gatewayv1.G
 					// If all backends were filtered, create a route with no backend (ghost returns 500)
 					if len(validNoMatchBackends) == 0 && len(rule.BackendRefs) > 0 {
 						collectedRoutes = append(collectedRoutes, ghost.Route{
-							Hostname:  hostname,
-							PathMatch: pathMatch,
-							Filters:   filters,
-							Service:   "",
-							Namespace: routeNS,
-							Port:      0,
-							Weight:    0,
-							Listeners: listeners,
-							RouteName: routeName,
-							RuleName:  ruleName,
-							Priority:  CalculateRoutePriority(pathMatch, nil, nil, nil),
-							RuleIndex: ruleIndex,
-							TimeoutMs: timeoutMs,
+							Hostname:         hostname,
+							PathMatch:        pathMatch,
+							Filters:          filters,
+							Service:          "",
+							Namespace:        routeNS,
+							Port:             0,
+							Weight:           0,
+							Listeners:        listeners,
+							RouteName:        routeName,
+							RuleName:         ruleName,
+							Priority:         CalculateRoutePriority(pathMatch, nil, nil, nil),
+							RuleIndex:        ruleIndex,
+							BackendTimeoutMs: backendTimeoutMs,
 						})
 					}
 
@@ -243,20 +243,20 @@ func CollectHTTPRouteBackends(routes []gatewayv1.HTTPRoute, gateway *gatewayv1.G
 						}
 
 						collectedRoutes = append(collectedRoutes, ghost.Route{
-							Hostname:  hostname,
-							PathMatch: pathMatch,
-							Filters:   filters,
-							Service:   string(backend.Name),
-							Namespace: backendNS,
-							Port:      port,
-							PortName:  portName,
-							Weight:    weight,
-							Listeners: listeners,
-							RouteName: routeName,
-							RuleName:  ruleName,
-							Priority:  CalculateRoutePriority(pathMatch, nil, nil, nil),
-							RuleIndex: ruleIndex,
-							TimeoutMs: timeoutMs,
+							Hostname:         hostname,
+							PathMatch:        pathMatch,
+							Filters:          filters,
+							Service:          string(backend.Name),
+							Namespace:        backendNS,
+							Port:             port,
+							PortName:         portName,
+							Weight:           weight,
+							Listeners:        listeners,
+							RouteName:        routeName,
+							RuleName:         ruleName,
+							Priority:         CalculateRoutePriority(pathMatch, nil, nil, nil),
+							RuleIndex:        ruleIndex,
+							BackendTimeoutMs: backendTimeoutMs,
 						})
 					}
 				} else {
@@ -349,22 +349,22 @@ func CollectHTTPRouteBackends(routes []gatewayv1.HTTPRoute, gateway *gatewayv1.G
 						if len(validBackendRefs) == 0 {
 							if filters != nil || len(rule.BackendRefs) > 0 {
 								collectedRoutes = append(collectedRoutes, ghost.Route{
-									Hostname:    hostname,
-									PathMatch:   pathMatch,
-									Method:      method,
-									Headers:     headers,
-									QueryParams: queryParams,
-									Filters:     filters,
-									Service:     "",
-									Namespace:   routeNS,
-									Port:        0,
-									Weight:      0,
-									Listeners:   listeners,
-									RouteName:   routeName,
-									RuleName:    ruleName,
-									Priority:    CalculateRoutePriority(pathMatch, method, headers, queryParams),
-									RuleIndex:   ruleIndex,
-									TimeoutMs:   timeoutMs,
+									Hostname:         hostname,
+									PathMatch:        pathMatch,
+									Method:           method,
+									Headers:          headers,
+									QueryParams:      queryParams,
+									Filters:          filters,
+									Service:          "",
+									Namespace:        routeNS,
+									Port:             0,
+									Weight:           0,
+									Listeners:        listeners,
+									RouteName:        routeName,
+									RuleName:         ruleName,
+									Priority:         CalculateRoutePriority(pathMatch, method, headers, queryParams),
+									RuleIndex:        ruleIndex,
+									BackendTimeoutMs: backendTimeoutMs,
 								})
 							}
 						}
@@ -400,23 +400,23 @@ func CollectHTTPRouteBackends(routes []gatewayv1.HTTPRoute, gateway *gatewayv1.G
 							}
 
 							collectedRoutes = append(collectedRoutes, ghost.Route{
-								Hostname:    hostname,
-								PathMatch:   pathMatch,
-								Method:      method,
-								Headers:     headers,
-								QueryParams: queryParams,
-								Filters:     filters,
-								Service:     string(backend.Name),
-								Namespace:   backendNS,
-								Port:        port,
-								PortName:    portName,
-								Weight:      weight,
-								Listeners:   listeners,
-								RouteName:   routeName,
-								RuleName:    ruleName,
-								Priority:    CalculateRoutePriority(pathMatch, method, headers, queryParams),
-								RuleIndex:   ruleIndex,
-								TimeoutMs:   timeoutMs,
+								Hostname:         hostname,
+								PathMatch:        pathMatch,
+								Method:           method,
+								Headers:          headers,
+								QueryParams:      queryParams,
+								Filters:          filters,
+								Service:          string(backend.Name),
+								Namespace:        backendNS,
+								Port:             port,
+								PortName:         portName,
+								Weight:           weight,
+								Listeners:        listeners,
+								RouteName:        routeName,
+								RuleName:         ruleName,
+								Priority:         CalculateRoutePriority(pathMatch, method, headers, queryParams),
+								RuleIndex:        ruleIndex,
+								BackendTimeoutMs: backendTimeoutMs,
 							})
 						}
 					}
@@ -449,14 +449,14 @@ func CollectHTTPRouteBackends(routes []gatewayv1.HTTPRoute, gateway *gatewayv1.G
 	return collectedRoutes
 }
 
-// routeTimeoutMs converts an HTTPRoute rule's timeouts into milliseconds for
+// routeBackendTimeoutMs converts an HTTPRoute rule's timeouts into milliseconds for
 // routing.json. Returns 0 when no timeout applies, and 0 is serialized as absent.
 //
 // request and backendRequest map onto the same Varnish fetch timeouts, so the
 // tighter of the two wins — the spec requires backendRequest <= request, but a
 // route that violates that must not end up with the looser bound. See
 // docs/reference/httproute-timeouts.md.
-func routeTimeoutMs(t *gatewayv1.HTTPRouteTimeouts) int {
+func routeBackendTimeoutMs(t *gatewayv1.HTTPRouteTimeouts) int {
 	if t == nil {
 		return 0
 	}

--- a/internal/vcl/generator.go
+++ b/internal/vcl/generator.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/varnish/gateway/internal/ghost"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -154,6 +155,10 @@ func CollectHTTPRouteBackends(routes []gatewayv1.HTTPRoute, gateway *gatewayv1.G
 					ruleName = string(*rule.Name)
 				}
 
+				// Timeouts are per-rule, so every route entry generated from this
+				// rule carries the same value.
+				timeoutMs := backendTimeoutMs(rule.Timeouts)
+
 				// Process each match in the rule
 				if len(rule.Matches) == 0 {
 					// No matches specified - create default route with PathPrefix "/"
@@ -174,18 +179,19 @@ func CollectHTTPRouteBackends(routes []gatewayv1.HTTPRoute, gateway *gatewayv1.G
 					// Handle filter-only routes with no backends (e.g., redirects with no matches)
 					if len(rule.BackendRefs) == 0 && filters != nil {
 						collectedRoutes = append(collectedRoutes, ghost.Route{
-							Hostname:  hostname,
-							PathMatch: pathMatch,
-							Filters:   filters,
-							Service:   "",
-							Namespace: routeNS,
-							Port:      0,
-							Weight:    0,
-							Listeners: listeners,
-							RouteName: routeName,
-							RuleName:  ruleName,
-							Priority:  CalculateRoutePriority(pathMatch, nil, nil, nil),
-							RuleIndex: ruleIndex,
+							Hostname:         hostname,
+							PathMatch:        pathMatch,
+							Filters:          filters,
+							Service:          "",
+							Namespace:        routeNS,
+							Port:             0,
+							Weight:           0,
+							Listeners:        listeners,
+							RouteName:        routeName,
+							RuleName:         ruleName,
+							Priority:         CalculateRoutePriority(pathMatch, nil, nil, nil),
+							RuleIndex:        ruleIndex,
+							BackendTimeoutMs: timeoutMs,
 						})
 					}
 
@@ -195,18 +201,19 @@ func CollectHTTPRouteBackends(routes []gatewayv1.HTTPRoute, gateway *gatewayv1.G
 					// If all backends were filtered, create a route with no backend (ghost returns 500)
 					if len(validNoMatchBackends) == 0 && len(rule.BackendRefs) > 0 {
 						collectedRoutes = append(collectedRoutes, ghost.Route{
-							Hostname:  hostname,
-							PathMatch: pathMatch,
-							Filters:   filters,
-							Service:   "",
-							Namespace: routeNS,
-							Port:      0,
-							Weight:    0,
-							Listeners: listeners,
-							RouteName: routeName,
-							RuleName:  ruleName,
-							Priority:  CalculateRoutePriority(pathMatch, nil, nil, nil),
-							RuleIndex: ruleIndex,
+							Hostname:         hostname,
+							PathMatch:        pathMatch,
+							Filters:          filters,
+							Service:          "",
+							Namespace:        routeNS,
+							Port:             0,
+							Weight:           0,
+							Listeners:        listeners,
+							RouteName:        routeName,
+							RuleName:         ruleName,
+							Priority:         CalculateRoutePriority(pathMatch, nil, nil, nil),
+							RuleIndex:        ruleIndex,
+							BackendTimeoutMs: timeoutMs,
 						})
 					}
 
@@ -236,19 +243,20 @@ func CollectHTTPRouteBackends(routes []gatewayv1.HTTPRoute, gateway *gatewayv1.G
 						}
 
 						collectedRoutes = append(collectedRoutes, ghost.Route{
-							Hostname:  hostname,
-							PathMatch: pathMatch,
-							Filters:   filters,
-							Service:   string(backend.Name),
-							Namespace: backendNS,
-							Port:      port,
-							PortName:  portName,
-							Weight:    weight,
-							Listeners: listeners,
-							RouteName: routeName,
-							RuleName:  ruleName,
-							Priority:  CalculateRoutePriority(pathMatch, nil, nil, nil),
-							RuleIndex: ruleIndex,
+							Hostname:         hostname,
+							PathMatch:        pathMatch,
+							Filters:          filters,
+							Service:          string(backend.Name),
+							Namespace:        backendNS,
+							Port:             port,
+							PortName:         portName,
+							Weight:           weight,
+							Listeners:        listeners,
+							RouteName:        routeName,
+							RuleName:         ruleName,
+							Priority:         CalculateRoutePriority(pathMatch, nil, nil, nil),
+							RuleIndex:        ruleIndex,
+							BackendTimeoutMs: timeoutMs,
 						})
 					}
 				} else {
@@ -341,21 +349,22 @@ func CollectHTTPRouteBackends(routes []gatewayv1.HTTPRoute, gateway *gatewayv1.G
 						if len(validBackendRefs) == 0 {
 							if filters != nil || len(rule.BackendRefs) > 0 {
 								collectedRoutes = append(collectedRoutes, ghost.Route{
-									Hostname:    hostname,
-									PathMatch:   pathMatch,
-									Method:      method,
-									Headers:     headers,
-									QueryParams: queryParams,
-									Filters:     filters,
-									Service:     "",
-									Namespace:   routeNS,
-									Port:        0,
-									Weight:      0,
-									Listeners:   listeners,
-									RouteName:   routeName,
-									RuleName:    ruleName,
-									Priority:    CalculateRoutePriority(pathMatch, method, headers, queryParams),
-									RuleIndex:   ruleIndex,
+									Hostname:         hostname,
+									PathMatch:        pathMatch,
+									Method:           method,
+									Headers:          headers,
+									QueryParams:      queryParams,
+									Filters:          filters,
+									Service:          "",
+									Namespace:        routeNS,
+									Port:             0,
+									Weight:           0,
+									Listeners:        listeners,
+									RouteName:        routeName,
+									RuleName:         ruleName,
+									Priority:         CalculateRoutePriority(pathMatch, method, headers, queryParams),
+									RuleIndex:        ruleIndex,
+									BackendTimeoutMs: timeoutMs,
 								})
 							}
 						}
@@ -391,22 +400,23 @@ func CollectHTTPRouteBackends(routes []gatewayv1.HTTPRoute, gateway *gatewayv1.G
 							}
 
 							collectedRoutes = append(collectedRoutes, ghost.Route{
-								Hostname:    hostname,
-								PathMatch:   pathMatch,
-								Method:      method,
-								Headers:     headers,
-								QueryParams: queryParams,
-								Filters:     filters,
-								Service:     string(backend.Name),
-								Namespace:   backendNS,
-								Port:        port,
-								PortName:    portName,
-								Weight:      weight,
-								Listeners:   listeners,
-								RouteName:   routeName,
-								RuleName:    ruleName,
-								Priority:    CalculateRoutePriority(pathMatch, method, headers, queryParams),
-								RuleIndex:   ruleIndex,
+								Hostname:         hostname,
+								PathMatch:        pathMatch,
+								Method:           method,
+								Headers:          headers,
+								QueryParams:      queryParams,
+								Filters:          filters,
+								Service:          string(backend.Name),
+								Namespace:        backendNS,
+								Port:             port,
+								PortName:         portName,
+								Weight:           weight,
+								Listeners:        listeners,
+								RouteName:        routeName,
+								RuleName:         ruleName,
+								Priority:         CalculateRoutePriority(pathMatch, method, headers, queryParams),
+								RuleIndex:        ruleIndex,
+								BackendTimeoutMs: timeoutMs,
 							})
 						}
 					}
@@ -437,6 +447,26 @@ func CollectHTTPRouteBackends(routes []gatewayv1.HTTPRoute, gateway *gatewayv1.G
 	})
 
 	return collectedRoutes
+}
+
+// backendTimeoutMs converts an HTTPRoute rule's timeouts.backendRequest into
+// milliseconds for routing.json. Returns 0 when the timeout is unset, "0s", or
+// unparseable, and 0 is serialized as absent.
+//
+// Gateway API defines "0s" as "disable the timeout". Varnish has no way to
+// uncap a fetch — first_byte_timeout/between_bytes_timeout always apply — so a
+// disabled route is emitted as absent and inherits varnishd's global defaults
+// rather than running unbounded. Documented in docs/reference/httproute-timeouts.md.
+func backendTimeoutMs(t *gatewayv1.HTTPRouteTimeouts) int {
+	if t == nil || t.BackendRequest == nil {
+		return 0
+	}
+	// GEP-2257 durations are a subset of time.ParseDuration's grammar.
+	d, err := time.ParseDuration(string(*t.BackendRequest))
+	if err != nil || d <= 0 {
+		return 0
+	}
+	return int(d.Milliseconds())
 }
 
 // filterValidBackends returns backend refs that have a valid Kind/Group and are not blocked.

--- a/internal/vcl/generator.go
+++ b/internal/vcl/generator.go
@@ -157,7 +157,7 @@ func CollectHTTPRouteBackends(routes []gatewayv1.HTTPRoute, gateway *gatewayv1.G
 
 				// Timeouts are per-rule, so every route entry generated from this
 				// rule carries the same value.
-				timeoutMs := backendTimeoutMs(rule.Timeouts)
+				timeoutMs := routeTimeoutMs(rule.Timeouts)
 
 				// Process each match in the rule
 				if len(rule.Matches) == 0 {
@@ -449,24 +449,51 @@ func CollectHTTPRouteBackends(routes []gatewayv1.HTTPRoute, gateway *gatewayv1.G
 	return collectedRoutes
 }
 
-// backendTimeoutMs converts an HTTPRoute rule's timeouts.backendRequest into
-// milliseconds for routing.json. Returns 0 when the timeout is unset, "0s", or
-// unparseable, and 0 is serialized as absent.
+// routeTimeoutMs converts an HTTPRoute rule's timeouts into milliseconds for
+// routing.json. Returns 0 when no timeout applies, and 0 is serialized as absent.
 //
-// Gateway API defines "0s" as "disable the timeout". Varnish has no way to
-// uncap a fetch — first_byte_timeout/between_bytes_timeout always apply — so a
-// disabled route is emitted as absent and inherits varnishd's global defaults
-// rather than running unbounded. Documented in docs/reference/httproute-timeouts.md.
-func backendTimeoutMs(t *gatewayv1.HTTPRouteTimeouts) int {
-	if t == nil || t.BackendRequest == nil {
+// Both request and backendRequest map onto the same Varnish fetch timeouts, so
+// the tighter of the two wins. Gateway API scopes request to the entire client
+// request-response cycle, but Varnish has no total-request timeout — the clock
+// necessarily starts at the backend fetch, so request behaves as an alias for
+// backendRequest. Documented in docs/reference/httproute-timeouts.md.
+func routeTimeoutMs(t *gatewayv1.HTTPRouteTimeouts) int {
+	if t == nil {
+		return 0
+	}
+	// The spec requires backendRequest <= request, but a route that violates
+	// that must not end up with the looser of the two bounds.
+	return minNonZeroMs(durationMs(t.Request), durationMs(t.BackendRequest))
+}
+
+// durationMs parses a GEP-2257 duration into milliseconds. Returns 0 when unset,
+// unparseable, or "0s".
+//
+// Gateway API defines "0s" as "disable the timeout". Varnish has no way to uncap
+// a fetch — first_byte_timeout/between_bytes_timeout always apply — so a disabled
+// route is emitted as absent and inherits varnishd's global defaults rather than
+// running unbounded.
+func durationMs(d *gatewayv1.Duration) int {
+	if d == nil {
 		return 0
 	}
 	// GEP-2257 durations are a subset of time.ParseDuration's grammar.
-	d, err := time.ParseDuration(string(*t.BackendRequest))
-	if err != nil || d <= 0 {
+	parsed, err := time.ParseDuration(string(*d))
+	if err != nil || parsed <= 0 {
 		return 0
 	}
-	return int(d.Milliseconds())
+	return int(parsed.Milliseconds())
+}
+
+// minNonZeroMs returns the smaller of two timeouts, treating 0 as "unset".
+func minNonZeroMs(a, b int) int {
+	if a == 0 {
+		return b
+	}
+	if b == 0 {
+		return a
+	}
+	return min(a, b)
 }
 
 // filterValidBackends returns backend refs that have a valid Kind/Group and are not blocked.

--- a/internal/vcl/generator_test.go
+++ b/internal/vcl/generator_test.go
@@ -101,9 +101,35 @@ func TestGenerate_GhostReloadHandler(t *testing.T) {
 		t.Error("expected vcl_recv to return synth(500) on failed reload")
 	}
 
-	// Should NOT have vcl_backend_error (reload handled in vcl_recv)
+	// Should NOT have vcl_backend_error. Reload errors are surfaced from vcl_recv,
+	// and the preamble runs BEFORE user VCL — a return here would stop user VCL
+	// from ever running. The 504 timeout flip lives in the postamble instead,
+	// which runs after user VCL. See TestMergePostambleBackendError.
 	if strings.Contains(result, "sub vcl_backend_error {") {
-		t.Error("should not have vcl_backend_error (reload handled in vcl_recv)")
+		t.Error("should not have vcl_backend_error in the preamble (see postamble.vcl)")
+	}
+}
+
+func TestMergePostambleBackendError(t *testing.T) {
+	// The 504 flip must land after user VCL so a user-defined vcl_backend_error
+	// runs first and can take over with its own return.
+	merged := Merge(Generate(), "sub vcl_backend_error { set beresp.http.X-User = \"1\"; }")
+
+	userIdx := strings.Index(merged, `set beresp.http.X-User = "1";`)
+	flipIdx := strings.Index(merged, "set beresp.status = 504;")
+	if userIdx == -1 {
+		t.Fatal("expected user vcl_backend_error in merged VCL")
+	}
+	if flipIdx == -1 {
+		t.Fatal("expected postamble 504 flip in merged VCL")
+	}
+	if flipIdx < userIdx {
+		t.Error("postamble vcl_backend_error must be concatenated after user VCL")
+	}
+
+	// The flip is scoped to routes that actually carry a timeout.
+	if !strings.Contains(merged, "if (bereq.http.X-Ghost-Timeout) {") {
+		t.Error("expected the 504 flip to be guarded on X-Ghost-Timeout")
 	}
 }
 
@@ -1247,5 +1273,106 @@ func TestNoMatchRuleMatchesExplicitSlashPriority(t *testing.T) {
 	}
 	if noMatchPrio != explicitPrio {
 		t.Errorf("no-match (%d) and explicit-/ (%d) priorities must be equal", noMatchPrio, explicitPrio)
+	}
+}
+
+func TestBackendTimeoutMs(t *testing.T) {
+	tests := []struct {
+		name     string
+		timeouts *gatewayv1.HTTPRouteTimeouts
+		want     int
+	}{
+		{"nil timeouts", nil, 0},
+		{"no backendRequest", &gatewayv1.HTTPRouteTimeouts{Request: ptr(gatewayv1.Duration("5s"))}, 0},
+		{"sub-second", &gatewayv1.HTTPRouteTimeouts{BackendRequest: ptr(gatewayv1.Duration("500ms"))}, 500},
+		{"whole seconds", &gatewayv1.HTTPRouteTimeouts{BackendRequest: ptr(gatewayv1.Duration("3s"))}, 3000},
+		{"compound", &gatewayv1.HTTPRouteTimeouts{BackendRequest: ptr(gatewayv1.Duration("1m30s"))}, 90000},
+		// Gateway API "0s" disables the timeout. Varnish cannot uncap a fetch, so
+		// it is emitted as absent and inherits varnishd's global defaults.
+		{"zero disables", &gatewayv1.HTTPRouteTimeouts{BackendRequest: ptr(gatewayv1.Duration("0s"))}, 0},
+		// A malformed value must never become 0 in a way that reaches VCL as a
+		// real timeout — it degrades to "no per-route timeout".
+		{"unparseable", &gatewayv1.HTTPRouteTimeouts{BackendRequest: ptr(gatewayv1.Duration("banana"))}, 0},
+		{"negative", &gatewayv1.HTTPRouteTimeouts{BackendRequest: ptr(gatewayv1.Duration("-5s"))}, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := backendTimeoutMs(tt.timeouts); got != tt.want {
+				t.Errorf("backendTimeoutMs() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCollectHTTPRouteBackends_BackendTimeout(t *testing.T) {
+	prefixType := gatewayv1.PathMatchPathPrefix
+	backendRef := []gatewayv1.HTTPBackendRef{
+		{BackendRef: gatewayv1.BackendRef{BackendObjectReference: gatewayv1.BackendObjectReference{
+			Name: "api-service", Port: ptr(gatewayv1.PortNumber(8080)),
+		}}},
+	}
+
+	routes := []gatewayv1.HTTPRoute{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "route-1", Namespace: "default"},
+			Spec: gatewayv1.HTTPRouteSpec{
+				Hostnames: []gatewayv1.Hostname{"api.example.com"},
+				Rules: []gatewayv1.HTTPRouteRule{
+					{
+						Matches: []gatewayv1.HTTPRouteMatch{
+							{Path: &gatewayv1.HTTPPathMatch{Type: &prefixType, Value: ptr("/timed")}},
+						},
+						BackendRefs: backendRef,
+						Timeouts:    &gatewayv1.HTTPRouteTimeouts{BackendRequest: ptr(gatewayv1.Duration("500ms"))},
+					},
+					{
+						Matches: []gatewayv1.HTTPRouteMatch{
+							{Path: &gatewayv1.HTTPPathMatch{Type: &prefixType, Value: ptr("/disabled")}},
+						},
+						BackendRefs: backendRef,
+						Timeouts:    &gatewayv1.HTTPRouteTimeouts{BackendRequest: ptr(gatewayv1.Duration("0s"))},
+					},
+					{
+						Matches: []gatewayv1.HTTPRouteMatch{
+							{Path: &gatewayv1.HTTPPathMatch{Type: &prefixType, Value: ptr("/untimed")}},
+						},
+						BackendRefs: backendRef,
+					},
+				},
+			},
+		},
+	}
+
+	collectedRoutes := CollectHTTPRouteBackends(routes, nil, "default", nil, nil, nil)
+
+	got := make(map[string]int)
+	for _, r := range collectedRoutes {
+		if r.PathMatch == nil {
+			t.Fatalf("expected a path match on every route, got %+v", r)
+		}
+		got[r.PathMatch.Value] = r.BackendTimeoutMs
+	}
+
+	want := map[string]int{"/timed": 500, "/disabled": 0, "/untimed": 0}
+	for path, wantMs := range want {
+		if got[path] != wantMs {
+			t.Errorf("route %s: BackendTimeoutMs = %d, want %d", path, got[path], wantMs)
+		}
+	}
+
+	// 0 must serialize as absent so ghost sees no per-route timeout at all,
+	// rather than a literal 0 it would bridge into bereq.first_byte_timeout.
+	for _, r := range collectedRoutes {
+		if r.PathMatch.Value != "/disabled" {
+			continue
+		}
+		data, err := json.Marshal(r)
+		if err != nil {
+			t.Fatalf("json.Marshal(route): %v", err)
+		}
+		if strings.Contains(string(data), "backend_timeout_ms") {
+			t.Errorf("disabled timeout must be omitted from routing.json, got %s", data)
+		}
 	}
 }

--- a/internal/vcl/generator_test.go
+++ b/internal/vcl/generator_test.go
@@ -101,10 +101,8 @@ func TestGenerate_GhostReloadHandler(t *testing.T) {
 		t.Error("expected vcl_recv to return synth(500) on failed reload")
 	}
 
-	// Should NOT have vcl_backend_error. Reload errors are surfaced from vcl_recv,
-	// and the preamble runs BEFORE user VCL — a return here would stop user VCL
-	// from ever running. The 504 timeout flip lives in the postamble instead,
-	// which runs after user VCL. See TestMergePostambleBackendError.
+	// The preamble runs BEFORE user VCL, so a return here would stop user VCL from
+	// ever running. The 504 flip lives in the postamble instead.
 	if strings.Contains(result, "sub vcl_backend_error {") {
 		t.Error("should not have vcl_backend_error in the preamble (see postamble.vcl)")
 	}
@@ -1283,15 +1281,12 @@ func TestRouteTimeoutMs(t *testing.T) {
 		want     int
 	}{
 		{"nil timeouts", nil, 0},
-		// request aliases backendRequest: Varnish has no total-request timeout.
 		{"request only", &gatewayv1.HTTPRouteTimeouts{Request: ptr(gatewayv1.Duration("5s"))}, 5000},
 		{"request disabled", &gatewayv1.HTTPRouteTimeouts{Request: ptr(gatewayv1.Duration("0s"))}, 0},
 		{"both set, backendRequest tighter", &gatewayv1.HTTPRouteTimeouts{
 			Request:        ptr(gatewayv1.Duration("5s")),
 			BackendRequest: ptr(gatewayv1.Duration("500ms")),
 		}, 500},
-		// The spec requires backendRequest <= request. A route that violates it
-		// must still get the tighter bound, not the looser one.
 		{"both set, request tighter", &gatewayv1.HTTPRouteTimeouts{
 			Request:        ptr(gatewayv1.Duration("1s")),
 			BackendRequest: ptr(gatewayv1.Duration("30s")),
@@ -1303,11 +1298,7 @@ func TestRouteTimeoutMs(t *testing.T) {
 		{"sub-second", &gatewayv1.HTTPRouteTimeouts{BackendRequest: ptr(gatewayv1.Duration("500ms"))}, 500},
 		{"whole seconds", &gatewayv1.HTTPRouteTimeouts{BackendRequest: ptr(gatewayv1.Duration("3s"))}, 3000},
 		{"compound", &gatewayv1.HTTPRouteTimeouts{BackendRequest: ptr(gatewayv1.Duration("1m30s"))}, 90000},
-		// Gateway API "0s" disables the timeout. Varnish cannot uncap a fetch, so
-		// it is emitted as absent and inherits varnishd's global defaults.
 		{"zero disables", &gatewayv1.HTTPRouteTimeouts{BackendRequest: ptr(gatewayv1.Duration("0s"))}, 0},
-		// A malformed value must never become 0 in a way that reaches VCL as a
-		// real timeout — it degrades to "no per-route timeout".
 		{"unparseable", &gatewayv1.HTTPRouteTimeouts{BackendRequest: ptr(gatewayv1.Duration("banana"))}, 0},
 		{"negative", &gatewayv1.HTTPRouteTimeouts{BackendRequest: ptr(gatewayv1.Duration("-5s"))}, 0},
 	}
@@ -1377,8 +1368,7 @@ func TestCollectHTTPRouteBackends_BackendTimeout(t *testing.T) {
 		}
 	}
 
-	// 0 must serialize as absent so ghost sees no per-route timeout at all,
-	// rather than a literal 0 it would bridge into bereq.first_byte_timeout.
+	// 0 must serialize as absent, not as a literal 0 ghost would bridge into bereq.
 	for _, r := range collectedRoutes {
 		if r.PathMatch.Value != "/disabled" {
 			continue

--- a/internal/vcl/generator_test.go
+++ b/internal/vcl/generator_test.go
@@ -163,6 +163,22 @@ func TestGenerate_DefaultGhostConfigPath(t *testing.T) {
 	}
 }
 
+func TestGenerate_RouteTimeoutSetsAllFetchTimeouts(t *testing.T) {
+	result := Generate()
+
+	// All three must move together: leaving connect_timeout at varnishd's 3.5s
+	// global lets an unreachable pod outlive a shorter route timeout.
+	for _, want := range []string{
+		"set bereq.connect_timeout = std.duration(bereq.http.X-Ghost-Timeout, 3.5s);",
+		"set bereq.first_byte_timeout = std.duration(bereq.http.X-Ghost-Timeout, 60s);",
+		"set bereq.between_bytes_timeout = std.duration(bereq.http.X-Ghost-Timeout, 60s);",
+	} {
+		if !strings.Contains(result, want) {
+			t.Errorf("expected %q in generated VCL", want)
+		}
+	}
+}
+
 func TestGenerate_DeterministicOutput(t *testing.T) {
 	first := Generate()
 
@@ -1379,6 +1395,67 @@ func TestCollectHTTPRouteBackends_BackendTimeout(t *testing.T) {
 		}
 		if strings.Contains(string(data), "backend_timeout_ms") {
 			t.Errorf("disabled timeout must be omitted from routing.json, got %s", data)
+		}
+	}
+}
+
+func TestCollectHTTPRouteBackends_TimeoutOnBackendlessRoutes(t *testing.T) {
+	// Routes that emit without a resolved backend — filter-only rules and rules
+	// whose backendRefs were all filtered out — still carry the rule's timeout.
+	prefixType := gatewayv1.PathMatchPathPrefix
+	redirect := []gatewayv1.HTTPRouteFilter{{
+		Type:            gatewayv1.HTTPRouteFilterRequestRedirect,
+		RequestRedirect: &gatewayv1.HTTPRequestRedirectFilter{StatusCode: ptr(302)},
+	}}
+	timeouts := &gatewayv1.HTTPRouteTimeouts{Request: ptr(gatewayv1.Duration("2s"))}
+
+	routes := []gatewayv1.HTTPRoute{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "route-1", Namespace: "default"},
+			Spec: gatewayv1.HTTPRouteSpec{
+				Hostnames: []gatewayv1.Hostname{"api.example.com"},
+				Rules: []gatewayv1.HTTPRouteRule{
+					{
+						// No matches, no backends: filter-only default route.
+						Name:     ptr(gatewayv1.SectionName("no-match-filter")),
+						Filters:  redirect,
+						Timeouts: timeouts,
+					},
+					{
+						// No matches, every backendRef filtered out by Kind.
+						Name: ptr(gatewayv1.SectionName("no-match-bad-backend")),
+						BackendRefs: []gatewayv1.HTTPBackendRef{{BackendRef: gatewayv1.BackendRef{
+							BackendObjectReference: gatewayv1.BackendObjectReference{
+								Name: "some-secret", Kind: ptr(gatewayv1.Kind("Secret")),
+							},
+						}}},
+						Timeouts: timeouts,
+					},
+					{
+						// Matched but backendless: filter-only redirect route.
+						Name: ptr(gatewayv1.SectionName("match-filter")),
+						Matches: []gatewayv1.HTTPRouteMatch{
+							{Path: &gatewayv1.HTTPPathMatch{Type: &prefixType, Value: ptr("/redirect")}},
+						},
+						Filters:  redirect,
+						Timeouts: timeouts,
+					},
+				},
+			},
+		},
+	}
+
+	got := make(map[string]int)
+	for _, r := range CollectHTTPRouteBackends(routes, nil, "default", nil, nil, nil) {
+		if r.Service != "" {
+			t.Fatalf("expected backendless routes only, got service %q", r.Service)
+		}
+		got[r.RuleName] = r.TimeoutMs
+	}
+
+	for _, name := range []string{"no-match-filter", "no-match-bad-backend", "match-filter"} {
+		if got[name] != 2000 {
+			t.Errorf("rule %s: TimeoutMs = %d, want 2000", name, got[name])
 		}
 	}
 }

--- a/internal/vcl/generator_test.go
+++ b/internal/vcl/generator_test.go
@@ -1276,14 +1276,30 @@ func TestNoMatchRuleMatchesExplicitSlashPriority(t *testing.T) {
 	}
 }
 
-func TestBackendTimeoutMs(t *testing.T) {
+func TestRouteTimeoutMs(t *testing.T) {
 	tests := []struct {
 		name     string
 		timeouts *gatewayv1.HTTPRouteTimeouts
 		want     int
 	}{
 		{"nil timeouts", nil, 0},
-		{"no backendRequest", &gatewayv1.HTTPRouteTimeouts{Request: ptr(gatewayv1.Duration("5s"))}, 0},
+		// request aliases backendRequest: Varnish has no total-request timeout.
+		{"request only", &gatewayv1.HTTPRouteTimeouts{Request: ptr(gatewayv1.Duration("5s"))}, 5000},
+		{"request disabled", &gatewayv1.HTTPRouteTimeouts{Request: ptr(gatewayv1.Duration("0s"))}, 0},
+		{"both set, backendRequest tighter", &gatewayv1.HTTPRouteTimeouts{
+			Request:        ptr(gatewayv1.Duration("5s")),
+			BackendRequest: ptr(gatewayv1.Duration("500ms")),
+		}, 500},
+		// The spec requires backendRequest <= request. A route that violates it
+		// must still get the tighter bound, not the looser one.
+		{"both set, request tighter", &gatewayv1.HTTPRouteTimeouts{
+			Request:        ptr(gatewayv1.Duration("1s")),
+			BackendRequest: ptr(gatewayv1.Duration("30s")),
+		}, 1000},
+		{"request set, backendRequest disabled", &gatewayv1.HTTPRouteTimeouts{
+			Request:        ptr(gatewayv1.Duration("2s")),
+			BackendRequest: ptr(gatewayv1.Duration("0s")),
+		}, 2000},
 		{"sub-second", &gatewayv1.HTTPRouteTimeouts{BackendRequest: ptr(gatewayv1.Duration("500ms"))}, 500},
 		{"whole seconds", &gatewayv1.HTTPRouteTimeouts{BackendRequest: ptr(gatewayv1.Duration("3s"))}, 3000},
 		{"compound", &gatewayv1.HTTPRouteTimeouts{BackendRequest: ptr(gatewayv1.Duration("1m30s"))}, 90000},
@@ -1298,8 +1314,8 @@ func TestBackendTimeoutMs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := backendTimeoutMs(tt.timeouts); got != tt.want {
-				t.Errorf("backendTimeoutMs() = %d, want %d", got, tt.want)
+			if got := routeTimeoutMs(tt.timeouts); got != tt.want {
+				t.Errorf("routeTimeoutMs() = %d, want %d", got, tt.want)
 			}
 		})
 	}

--- a/internal/vcl/generator_test.go
+++ b/internal/vcl/generator_test.go
@@ -1358,13 +1358,13 @@ func TestCollectHTTPRouteBackends_BackendTimeout(t *testing.T) {
 		if r.PathMatch == nil {
 			t.Fatalf("expected a path match on every route, got %+v", r)
 		}
-		got[r.PathMatch.Value] = r.BackendTimeoutMs
+		got[r.PathMatch.Value] = r.TimeoutMs
 	}
 
 	want := map[string]int{"/timed": 500, "/disabled": 0, "/untimed": 0}
 	for path, wantMs := range want {
 		if got[path] != wantMs {
-			t.Errorf("route %s: BackendTimeoutMs = %d, want %d", path, got[path], wantMs)
+			t.Errorf("route %s: TimeoutMs = %d, want %d", path, got[path], wantMs)
 		}
 	}
 

--- a/internal/vcl/generator_test.go
+++ b/internal/vcl/generator_test.go
@@ -1290,7 +1290,7 @@ func TestNoMatchRuleMatchesExplicitSlashPriority(t *testing.T) {
 	}
 }
 
-func TestRouteTimeoutMs(t *testing.T) {
+func TestRouteBackendTimeoutMs(t *testing.T) {
 	tests := []struct {
 		name     string
 		timeouts *gatewayv1.HTTPRouteTimeouts
@@ -1321,8 +1321,8 @@ func TestRouteTimeoutMs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := routeTimeoutMs(tt.timeouts); got != tt.want {
-				t.Errorf("routeTimeoutMs() = %d, want %d", got, tt.want)
+			if got := routeBackendTimeoutMs(tt.timeouts); got != tt.want {
+				t.Errorf("routeBackendTimeoutMs() = %d, want %d", got, tt.want)
 			}
 		})
 	}
@@ -1374,13 +1374,13 @@ func TestCollectHTTPRouteBackends_BackendTimeout(t *testing.T) {
 		if r.PathMatch == nil {
 			t.Fatalf("expected a path match on every route, got %+v", r)
 		}
-		got[r.PathMatch.Value] = r.TimeoutMs
+		got[r.PathMatch.Value] = r.BackendTimeoutMs
 	}
 
 	want := map[string]int{"/timed": 500, "/disabled": 0, "/untimed": 0}
 	for path, wantMs := range want {
 		if got[path] != wantMs {
-			t.Errorf("route %s: TimeoutMs = %d, want %d", path, got[path], wantMs)
+			t.Errorf("route %s: BackendTimeoutMs = %d, want %d", path, got[path], wantMs)
 		}
 	}
 
@@ -1450,12 +1450,12 @@ func TestCollectHTTPRouteBackends_TimeoutOnBackendlessRoutes(t *testing.T) {
 		if r.Service != "" {
 			t.Fatalf("expected backendless routes only, got service %q", r.Service)
 		}
-		got[r.RuleName] = r.TimeoutMs
+		got[r.RuleName] = r.BackendTimeoutMs
 	}
 
 	for _, name := range []string{"no-match-filter", "no-match-bad-backend", "match-filter"} {
 		if got[name] != 2000 {
-			t.Errorf("rule %s: TimeoutMs = %d, want 2000", name, got[name])
+			t.Errorf("rule %s: BackendTimeoutMs = %d, want 2000", name, got[name])
 		}
 	}
 }

--- a/internal/vcl/postamble.vcl
+++ b/internal/vcl/postamble.vcl
@@ -7,3 +7,21 @@ sub vcl_recv {
         return (pass);
     }
 }
+
+sub vcl_backend_error {
+    # A fetch failure on a route with timeouts.backendRequest set reports 504
+    # instead of Varnish's default 503. Routes without a timeout keep 503.
+    #
+    # Only status and reason are touched — deliberately no return(deliver) — so
+    # builtin.vcl still renders the error body, and a user vcl_backend_error that
+    # returns first keeps full control (its return means this never runs).
+    #
+    # Note: this cannot distinguish a timeout from any other fetch failure on a
+    # timeout-configured route. A refused connection on such a route also reports
+    # 504. Varnish exposes no failure reason in vcl_backend_error.
+    if (bereq.http.X-Ghost-Timeout) {
+        set beresp.status = 504;
+        set beresp.reason = "Gateway Timeout";
+        set beresp.ttl = 0s;
+    }
+}

--- a/internal/vcl/postamble.vcl
+++ b/internal/vcl/postamble.vcl
@@ -9,16 +9,14 @@ sub vcl_recv {
 }
 
 sub vcl_backend_error {
-    # A fetch failure on a route with timeouts.backendRequest set reports 504
-    # instead of Varnish's default 503. Routes without a timeout keep 503.
-    #
+    # Report 504 rather than Varnish's default 503 on routes carrying a timeout.
     # Only status and reason are touched — deliberately no return(deliver) — so
     # builtin.vcl still renders the error body, and a user vcl_backend_error that
     # returns first keeps full control (its return means this never runs).
     #
-    # Note: this cannot distinguish a timeout from any other fetch failure on a
-    # timeout-configured route. A refused connection on such a route also reports
-    # 504. Varnish exposes no failure reason in vcl_backend_error.
+    # Cannot distinguish a timeout from any other fetch failure on such a route:
+    # a refused connection also reports 504. Varnish exposes no failure reason
+    # in vcl_backend_error.
     if (bereq.http.X-Ghost-Timeout) {
         set beresp.status = 504;
         set beresp.reason = "Gateway Timeout";

--- a/internal/vcl/preamble.vcl
+++ b/internal/vcl/preamble.vcl
@@ -115,11 +115,17 @@ sub vcl_backend_fetch {
     # Deliberately NOT unset here: it must survive the fetch so the postamble
     # vcl_backend_error can tell a timed-out route apart from an ordinary 503.
     #
-    # The std.duration() fallback is 60s (varnishd's first_byte_timeout default),
-    # never 0s: a malformed value must not become "time out immediately".
+    # connect_timeout is included so an unreachable pod fails inside the route's
+    # budget instead of varnishd's 3.5s global. Gateway API scopes backendRequest
+    # to after request headers are sent, but the bound users want is their own
+    # wall-clock wait.
+    #
+    # Each std.duration() fallback is that parameter's varnishd default, never 0s:
+    # a malformed value must not become "time out immediately".
     # ponytail: between_bytes bounds the gap between body bytes, not the total —
     # a slow drip still streams forever, and SSE on a timed-out route gets cut.
     if (bereq.http.X-Ghost-Timeout) {
+        set bereq.connect_timeout = std.duration(bereq.http.X-Ghost-Timeout, 3.5s);
         set bereq.first_byte_timeout = std.duration(bereq.http.X-Ghost-Timeout, 60s);
         set bereq.between_bytes_timeout = std.duration(bereq.http.X-Ghost-Timeout, 60s);
     }

--- a/internal/vcl/preamble.vcl
+++ b/internal/vcl/preamble.vcl
@@ -109,22 +109,16 @@ sub vcl_backend_fetch {
     # at the end of vcl_backend_response instead.
     unset bereq.http.X-Ghost-Pass;
 
-    # Per-route backend timeout (HTTPRoute timeouts.backendRequest). Ghost sets
-    # X-Ghost-Timeout in vcl_recv; backends are pooled by address:port so they
-    # cannot carry per-route timeouts themselves.
+    # Per-route timeout. Ghost sets X-Ghost-Timeout in vcl_recv because backends
+    # are pooled by address:port and cannot carry per-route timeouts themselves.
     #
-    # The header is deliberately NOT unset here: it must survive the fetch so the
-    # postamble vcl_backend_error can tell a timed-out route apart from an
-    # ordinary 503. Same lifetime as the cache policy headers above.
+    # Deliberately NOT unset here: it must survive the fetch so the postamble
+    # vcl_backend_error can tell a timed-out route apart from an ordinary 503.
     #
     # The std.duration() fallback is 60s (varnishd's first_byte_timeout default),
     # never 0s: a malformed value must not become "time out immediately".
-    #
-    # between_bytes_timeout is set alongside first_byte_timeout because Gateway
-    # API scopes backendRequest to the complete response, not just its first
-    # byte. Varnish has no total-fetch cap, so this is the closest approximation.
-    # ponytail: bounds the gap between body bytes, not the total — a slow drip
-    # still streams forever, and long-lived SSE on a timed-out route will be cut.
+    # ponytail: between_bytes bounds the gap between body bytes, not the total —
+    # a slow drip still streams forever, and SSE on a timed-out route gets cut.
     if (bereq.http.X-Ghost-Timeout) {
         set bereq.first_byte_timeout = std.duration(bereq.http.X-Ghost-Timeout, 60s);
         set bereq.between_bytes_timeout = std.duration(bereq.http.X-Ghost-Timeout, 60s);

--- a/internal/vcl/preamble.vcl
+++ b/internal/vcl/preamble.vcl
@@ -29,6 +29,7 @@ sub vcl_recv {
     unset req.http.X-Ghost-Grace;
     unset req.http.X-Ghost-Keep;
     unset req.http.X-Ghost-Cache-Key-Extra;
+    unset req.http.X-Ghost-Timeout;
     unset req.http.X-Ghost-Filter-Context;
     unset req.http.X-Ghost-Redirect-Config;
     unset req.http.X-Ghost-Error;
@@ -107,6 +108,27 @@ sub vcl_backend_fetch {
     # because vcl_backend_response needs to read them. They are cleaned up
     # at the end of vcl_backend_response instead.
     unset bereq.http.X-Ghost-Pass;
+
+    # Per-route backend timeout (HTTPRoute timeouts.backendRequest). Ghost sets
+    # X-Ghost-Timeout in vcl_recv; backends are pooled by address:port so they
+    # cannot carry per-route timeouts themselves.
+    #
+    # The header is deliberately NOT unset here: it must survive the fetch so the
+    # postamble vcl_backend_error can tell a timed-out route apart from an
+    # ordinary 503. Same lifetime as the cache policy headers above.
+    #
+    # The std.duration() fallback is 60s (varnishd's first_byte_timeout default),
+    # never 0s: a malformed value must not become "time out immediately".
+    #
+    # between_bytes_timeout is set alongside first_byte_timeout because Gateway
+    # API scopes backendRequest to the complete response, not just its first
+    # byte. Varnish has no total-fetch cap, so this is the closest approximation.
+    # ponytail: bounds the gap between body bytes, not the total — a slow drip
+    # still streams forever, and long-lived SSE on a timed-out route will be cut.
+    if (bereq.http.X-Ghost-Timeout) {
+        set bereq.first_byte_timeout = std.duration(bereq.http.X-Ghost-Timeout, 60s);
+        set bereq.between_bytes_timeout = std.duration(bereq.http.X-Ghost-Timeout, 60s);
+    }
 }
 
 sub vcl_backend_response {
@@ -151,6 +173,7 @@ sub vcl_backend_response {
     unset bereq.http.X-Ghost-Forced-TTL;
     unset bereq.http.X-Ghost-Grace;
     unset bereq.http.X-Ghost-Keep;
+    unset bereq.http.X-Ghost-Timeout;
 }
 
 sub vcl_deliver {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -134,6 +134,7 @@ nav:
       - Troubleshooting: operations/troubleshooting.md
   - Reference:
       - HTTPRoute Filters: reference/httproute-filters.md
+      - HTTPRoute Timeouts: reference/httproute-timeouts.md
       - GatewayClassParameters: reference/gatewayclassparameters.md
       - VarnishCachePolicy: reference/varnishcachepolicy.md
       - VarnishCacheInvalidation: reference/varnishcacheinvalidation.md


### PR DESCRIPTION
Stacked PRs aren't supported from forks yet, so everything is folded into this one. Closes #24.

HTTPRoute `timeouts.backendRequest` and `timeouts.request`, mapped onto Varnish's fetch timeouts. A route that exceeds its budget returns 504.

## Against the issue's notes

| Note | Outcome |
|---|---|
| Varnish has `first_byte_timeout` / `between_bytes_timeout` | Both set, plus `connect_timeout`, to the same value |
| Map Gateway API semantics onto them | Done — `between_bytes_timeout` bounds the gap between body bytes, not the total, so the scope differs slightly from spec |
| Propagate routing.json → ghost.json → ghost | `backend_timeout_ms`, in the merge key so differing timeouts don't collapse |
| Ghost sets timeouts per matched route | Via `X-Ghost-Timeout` on the request — backends are pooled by `address:port` and can't carry per-route values |
| `request` may need `req_timeout` | Neither. `timeout_req` is global and covers request *receipt*, so `request` is an alias for `backendRequest`; tighter of the two wins |

Also: `0s` ("disable") is emitted as absent and inherits varnishd's globals — Varnish can't uncap a fetch. The 504 flip lives in the postamble so a user `vcl_backend_error` keeps precedence.

**The one judgment call:** `connect_timeout` moves with the other two. Connect happens before request headers are sent, so it's strictly outside `backendRequest`'s scope — but it's what makes an unreachable pod fail in 0.5s instead of varnishd's 3.5s. A tight timeout to an off-cluster backend now has to fit the TCP and TLS handshake.

Caveats (no total-request cap, streaming cut mid-body, no retries) are in `docs/reference/httproute-timeouts.md`.

## Testing

`make test-go`, `make test-ghost`, and conformance `HTTPRouteTimeoutBackendRequest` + `HTTPRouteTimeoutRequest` all pass.

By hand on kind against `echo-basic`, which honours `?delay=`:

| Route | Timeout | Result |
|---|---|---|
| `/backend-timeout?delay=1s` | `backendRequest: 500ms` | 504 @ 0.509s |
| `/backend-timeout` | `backendRequest: 500ms` | 200 @ 0.004s |
| `/disable-backend-timeout?delay=1s` | `backendRequest: 0s` | 200 @ 1.005s |
| `/request-timeout?delay=1s` | `request: 500ms` | 504 @ 0.510s |
| `/disable-request-timeout?delay=1s` | `request: 0s` | 200 @ 1.007s |
| `/generous-timeout?delay=1s` | `backendRequest: 5s` | 200 @ 1.008s |
| `/both-timeouts?delay=1s` | `request: 10s` + `backendRequest: 500ms` | 504 @ 0.510s |
| `/no-timeout?delay=1s` | none | 200 @ 1.008s |
| `/unreachable` | `backendRequest: 500ms` | 504 @ 0.5s |
| `/unreachable-no-timeout` | none | 503 @ 3.52s |

- `/generous-timeout` vs `/backend-timeout` brackets the millisecond conversion both ways — 5s read as 5ms would 504, 500ms read as 500s would 200
- `/both-timeouts` confirms the tighter value wins: routing.json carries `backend_timeout_ms: 500`, not 10000
- The `/unreachable` pair isolates connect time — same blackholed address (`192.0.2.1`, SYN dropped not refused), differing only in whether the rule carries a timeout

** Disclaimer: I researched and partially built this with Claude Opus 5 and GLM 5.2, though testing and review were done by hand **
